### PR TITLE
feat: apply focus-visible polyfill to shadow root

### DIFF
--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -9,7 +9,8 @@ import { classMap } from 'lit-html/directives/class-map';
 import 'focus-visible/dist/focus-visible.min.js';
 import styleCss from "./style-css.js";
 import styleCssFixed from './style-fixed-css.js';
-import "@alaskaairux/auro-loader";
+import '@alaskaairux/auro-loader';
+import { isFocusVisibleSupported, isFocusVisiblePolyfillAvailable } from './util';
 
 /**
  * @attr {Boolean} fixed - uses px values instead of rem
@@ -31,6 +32,13 @@ import "@alaskaairux/auro-loader";
  * @slot - Provide text for the button.
  */
 class AuroButton extends LitElement {
+  constructor() {
+    super();
+    if (!isFocusVisibleSupported() && isFocusVisiblePolyfillAvailable()) {
+      window.applyFocusVisiblePolyfill(this.shadowRoot);
+    }
+  }
+
   static get styles() {
     return [
       styleCss,

--- a/src/style-ld.scss
+++ b/src/style-ld.scss
@@ -6,8 +6,4 @@
 // import button styles into element namespaced wrapper
 auro-button-light {
   @import './style.scss';
-
-  .focus-visible.auro-button {
-    @include focus-visible;
-  }
 }

--- a/src/style.scss
+++ b/src/style.scss
@@ -22,6 +22,7 @@ $auro-inset-directions:'--squish';
 
 // focus-visible mixin
 @mixin focus-visible {
+  outline: 3px solid transparent;
   box-shadow: inset 0 0 0 1px var(--auro-color-border-focus-on-dark), inset 0 0 0 3px var(--auro-color-background-lightest);
 
   // auro-button--secondary
@@ -57,16 +58,12 @@ $auro-inset-directions:'--squish';
   }
 }
 
-// handle focus-visible state
-:host(.focus-visible) {
-  .auro-button {
-    @include focus-visible;
+:focus-visible.auro-button {
+  @include focus-visible;
+}
 
-    &::-moz-focus-inner {
-      border: none;
-      width: 100%;
-    }
-  }
+.focus-visible.auro-button {
+  @include focus-visible;
 }
 
 :host([fluid]),
@@ -126,11 +123,6 @@ slot {
       background-color: var(--auro-color-ui-hover-on-light);
       border: 1px solid var(--auro-color-ui-hover-on-light);
     }
-  }
-
-  // remove Firefox-only focus outline
-  &::-moz-focus-inner {
-    border: none;
   }
 
   // handle active state

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,13 @@
+export function isFocusVisibleSupported() {
+  try {
+    document.querySelector(':focus-visible');
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+// https://github.com/WICG/focus-visible#shadow-dom
+export function isFocusVisiblePolyfillAvailable() {
+  return window.applyFocusVisiblePolyfill != null;
+}


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #97 

## Summary:

This PR applies the focus-visible polyfill [to the shadow root](https://github.com/WICG/focus-visible#shadow-dom). Previously, we could only detect focus-visible by the class being applied to the `<auro-button>` host itself. By applying it to the shadow root, we now see the class applied to the inner button element. Since native :focus-visible is now supported in Chrome and Firefox, we only apply the polyfill if we detect that :focus-visible is not supported (i.e., WebKit + IE). This should improve performance.

This also fixes the linked issue where auro-buttons nested inside another web component were not receiving focus styles without any effort needed by the consumer of this component.

The focus state has also been updated to remove outline to prepare for upcoming WCSS changes (https://github.com/AlaskaAirlines/WebCoreStyleSheets/pull/66)

## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
