### PR TITLE
fix: prevent errors with createElement

### DIFF
--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -33,8 +33,8 @@ import version from './version';
  * @slot - Provide text for the button.
  */
 class AuroButton extends LitElement {
-  constructor() {
-    super();
+  connectedCallback() {
+    super.connectedCallback();
     if (!isFocusVisibleSupported() && isFocusVisiblePolyfillAvailable()) {
       window.applyFocusVisiblePolyfill(this.shadowRoot);
     }


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #112

## Summary:

Initializing the focus-visible polyfill in the constructor was throwing an error when calling `document.createElement('auro-button')`. This PR moves the polyfill initialization to `connectedCallback`.

In particular, this was throwing exceptions in unit tests run with JSDOM.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
