### PR TITLE
fix: default boolean props to false #121

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,22 +8,22 @@
 
 ## Properties
 
-| Property         | Attribute        | Type      | Description                                      |
-|------------------|------------------|-----------|--------------------------------------------------|
-| `arialabel`      | `arialabel`      | `Boolean` | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
-| `arialabelledby` | `arialabelledby` | `Boolean` | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
-| `autofocus`      | `autofocus`      | `Boolean` | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
-| `disabled`       | `disabled`       | `Boolean` | If set to true button will become disabled and not allow for interactions |
-| `id`             | `id`             | `Boolean` | Set the unique ID of an element.                 |
-| `loading`        | `loading`        | `Boolean` | If set to true button text will be replaced with `auro-loader` and become disabled |
-| `ondark`         | `ondark`         | `Boolean` | Set value for on-dark version of auro-button     |
-| `secondary`      | `secondary`      | `Boolean` | Set value for secondary version of auro-button   |
-| `svgIconLeft`    | `svgIconLeft`    | `Boolean` | **DEPRECATED** Use auro-icon                     |
-| `svgIconRight`   | `svgIconRight`   | `Boolean` | **DEPRECATED** Use auro-icon                     |
-| `tertiary`       | `tertiary`       | `Boolean` | Set value for tertiary version of auro-button    |
-| `title`          | `title`          | `Boolean` | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
-| `type`           | `type`           | `Boolean` | The type of the button. Possible values are: `submit`, `reset`, `button` |
-| `value`          | `value`          | `Boolean` | Defines the value associated with the button which is submitted with the form data. |
+| Property         | Attribute        | Type      | Default | Description                                      |
+|------------------|------------------|-----------|---------|--------------------------------------------------|
+| `arialabel`      | `arialabel`      | `Boolean` |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
+| `arialabelledby` | `arialabelledby` | `Boolean` |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
+| `autofocus`      | `autofocus`      | `Boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
+| `disabled`       | `disabled`       | `Boolean` | false   | If set to true button will become disabled and not allow for interactions |
+| `id`             | `id`             | `Boolean` |         | Set the unique ID of an element.                 |
+| `loading`        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
+| `ondark`         | `ondark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
+| `secondary`      | `secondary`      | `Boolean` | false   | Set value for secondary version of auro-button   |
+| `svgIconLeft`    | `svgIconLeft`    | `Boolean` |         | **DEPRECATED** Use auro-icon                     |
+| `svgIconRight`   | `svgIconRight`   | `Boolean` |         | **DEPRECATED** Use auro-icon                     |
+| `tertiary`       | `tertiary`       | `Boolean` | false   | Set value for tertiary version of auro-button    |
+| `title`          | `title`          | `Boolean` |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
+| `type`           | `type`           | `Boolean` |         | The type of the button. Possible values are: `submit`, `reset`, `button` |
+| `value`          | `value`          | `Boolean` |         | Defines the value associated with the button which is submitted with the form data. |
 
 ## Slots
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,20 +10,20 @@
 
 | Property         | Attribute        | Type      | Default | Description                                      |
 |------------------|------------------|-----------|---------|--------------------------------------------------|
-| `arialabel`      | `arialabel`      | `Boolean` |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
-| `arialabelledby` | `arialabelledby` | `Boolean` |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
+| `arialabel`      | `arialabel`      | `String`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
+| `arialabelledby` | `arialabelledby` | `String`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
 | `autofocus`      | `autofocus`      | `Boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
 | `disabled`       | `disabled`       | `Boolean` | false   | If set to true button will become disabled and not allow for interactions |
-| `id`             | `id`             | `Boolean` |         | Set the unique ID of an element.                 |
+| `id`             | `id`             | `String`  |         | Set the unique ID of an element.                 |
 | `loading`        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
 | `ondark`         | `ondark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
 | `secondary`      | `secondary`      | `Boolean` | false   | Set value for secondary version of auro-button   |
-| `svgIconLeft`    | `svgIconLeft`    | `Boolean` |         | **DEPRECATED** Use auro-icon                     |
-| `svgIconRight`   | `svgIconRight`   | `Boolean` |         | **DEPRECATED** Use auro-icon                     |
+| `svgIconLeft`    | `svgIconLeft`    | `String`  |         | **DEPRECATED** Use auro-icon                     |
+| `svgIconRight`   | `svgIconRight`   | `String`  |         | **DEPRECATED** Use auro-icon                     |
 | `tertiary`       | `tertiary`       | `Boolean` | false   | Set value for tertiary version of auro-button    |
-| `title`          | `title`          | `Boolean` |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
-| `type`           | `type`           | `Boolean` |         | The type of the button. Possible values are: `submit`, `reset`, `button` |
-| `value`          | `value`          | `Boolean` |         | Defines the value associated with the button which is submitted with the form data. |
+| `title`          | `title`          | `String`  |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
+| `type`           | `type`           | `String`  |         | The type of the button. Possible values are: `submit`, `reset`, `button` |
+| `value`          | `value`          | `String`  |         | Defines the value associated with the button which is submitted with the form data. |
 
 ## Slots
 

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -33,6 +33,16 @@ import version from './version';
  * @slot - Provide text for the button.
  */
 class AuroButton extends LitElement {
+  constructor() {
+    super();
+    this.autofocus = false;
+    this.disabled = false;
+    this.loading = false;
+    this.ondark = false;
+    this.secondary = false;
+    this.tertiary = false;
+  }
+
   connectedCallback() {
     super.connectedCallback();
     if (!isFocusVisibleSupported() && isFocusVisiblePolyfillAvailable()) {

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -21,14 +21,14 @@ import version from './version';
  * @attr {Boolean} ondark - Set value for on-dark version of auro-button
  * @attr {Boolean} secondary - Set value for secondary version of auro-button
  * @attr {Boolean} tertiary - Set value for tertiary version of auro-button
- * @attr {Boolean} arialabel - Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead.
- * @attr {Boolean} arialabelledby - Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion.
- * @attr {Boolean} id - Set the unique ID of an element.
- * @attr {Boolean} title - Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element.
- * @attr {Boolean} type - The type of the button. Possible values are: `submit`, `reset`, `button`
- * @attr {Boolean} value - Defines the value associated with the button which is submitted with the form data.
- * @attr {Boolean} svgIconLeft - **DEPRECATED** Use auro-icon
- * @attr {Boolean} svgIconRight - **DEPRECATED** Use auro-icon
+ * @attr {String} arialabel - Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead.
+ * @attr {String} arialabelledby - Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion.
+ * @attr {String} id - Set the unique ID of an element.
+ * @attr {String} title - Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element.
+ * @attr {String} type - The type of the button. Possible values are: `submit`, `reset`, `button`
+ * @attr {String} value - Defines the value associated with the button which is submitted with the form data.
+ * @attr {String} svgIconLeft - **DEPRECATED** Use auro-icon
+ * @attr {String} svgIconRight - **DEPRECATED** Use auro-icon
  *
  * @slot - Provide text for the button.
  */


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #121

## Summary:

- Default all boolean properties to false. This enables Svelte apps to use the boolean attribute shorthand, e.g. `<auro-button disabled>`
- Update mis-typed property docs. String properties were documented as being boolean.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
