### PR TITLE
fix: allow wider range of lit-html versions #127

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-button",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@alaskaairux/auro-loader": "^1.1.0",
     "chalk": "^4.1.1",
     "lit-element": "^2.5.1",
-    "lit-html": "^1.4.1"
+    "lit-html": "^1.0.0"
   },
   "peerDependencies": {
     "@alaskaairux/design-tokens": "^3.0.0",


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes #127

## Summary:

https://github.com/AlaskaAirlines/auro-button/commit/da4edec51e7cb1d50f7d6a2f09f60144960f1b07 added lit-html as a direct dependency to fix a separate issue. However, the version range was too restrictive, allowing for the possibility that multiple lit-html versions could be installed at once. When this happens, the component breaks.

This PR attempts to fix the issue by being very permissive as to the version of lit-html installed, as recommended in the [lit docs](https://lit-element.polymer-project.org/guide/templates#using-other-lit-html-features). I had to edit the package.json manually because running `npm i lit-html@^1.0.0` put the latest version in the package.json.

I'm not 100% sure this will fix it, but I'm pretty sure.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
