### PR TITLE
fix: reflect ID prop #130

### DIFF
--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -103,7 +103,10 @@ class AuroButton extends LitElement {
         type: String,
         reflect: true
       },
-      id:               { type: String },
+      id:               {
+        type: String,
+        reflect: true
+       },
       svgIconLeft:      { type: String },
       svgIconRight:     { type: String },
     };


### PR DESCRIPTION
# Alaska Airlines Pull Request

Related to #130, but does not close the issue. That issue should be left open for future work to remove the ID prop entirely.

## Summary:

Reflect the ID property to the attribute. This now behaves like the native browser ID property.

You can now query auro-button by ID when only the property was set.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
