### PR TITLE
feat: add slim padding

### DIFF
--- a/demo/demo.md
+++ b/demo/demo.md
@@ -87,6 +87,88 @@ For default spacing of elements in a row, use the [.auro_containedButtons](https
 
 </auro-accordion>
 
+## Slim style
+
+Use the `slim` attribute with the `auro-button` element for a slim style with less padding. The slim style is used to establish the lowest level of hierarchy. Slim buttons have the least emphasis and significance on a page.
+
+<div class="exampleWrapper auro_containedButtons">
+  <auro-button slim>Primary</auro-button>
+  <auro-button slim secondary>Secondary</auro-button>
+  <auro-button slim tertiary>Tertiary</auro-button>
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+  ```html
+  <div class="exampleWrapper auro_containedButtons">
+    <auro-button slim>Primary</auro-button>
+    <auro-button slim secondary>Secondary</auro-button>
+    <auro-button slim tertiary>Tertiary</auro-button>
+  </div>
+  ```
+
+</auro-accordion>
+
+<div class="exampleWrapper auro_containedButtons">
+  <auro-button slim>
+    Activate WiFi
+    <auro-icon style="width: var(--auro-size-md)"
+      customSize
+      customcolor
+      category="in-flight" name="wifi">
+    </auro-icon>
+  </auro-button>
+
+  <auro-button slim secondary>
+    <auro-icon style="width: var(--auro-size-md)"
+      customSize
+      customcolor
+      category="interface" name="arrow-left"></auro-icon>
+    Previous action
+  </auro-button>
+
+  <auro-button slim tertiary>
+    Love this ...
+    <auro-icon style="width: var(--auro-size-md)"
+      customSize
+      customcolor
+      category="interface" name="heart-filled"></auro-icon>
+  </auro-button>
+</div>
+
+<auro-accordion lowProfile justifyRight>
+  <span slot="trigger">See code</span>
+
+  ```html
+  <auro-button slim>
+    Activate WiFi
+    <auro-icon style="width: var(--auro-size-md)"
+      customSize
+      customcolor
+      category="in-flight" name="wifi">
+    </auro-icon>
+  </auro-button>
+
+  <auro-button slim secondary>
+    <auro-icon style="width: var(--auro-size-md)"
+      customSize
+      customcolor
+      category="interface" name="arrow-left"></auro-icon>
+    Previous action
+  </auro-button>
+
+  <auro-button slim tertiary>
+    Love this ...
+    <auro-icon style="width: var(--auro-size-md)"
+      customSize
+      customcolor
+      category="interface" name="heart-filled"></auro-icon>
+  </auro-button>
+  ```
+
+</auro-accordion>
+
 ## Icon support
 
 Adding icons to the auro-button component is as easy as nesting any other HTML. The [auro-icon component](https://www.alaskaair.com/components/auro/icon) has access to all the icons listed in the [Auro Icons library](https://www.alaskaair.com/icons/usage) for quick and easy use.
@@ -289,4 +371,6 @@ Don't combine `disabled` and `loading` attributes on any single instance of `aur
 ```html
 <auro-button loading>Primary</auro-button>
 ```
+</auro-accordion>
+
 </auro-accordion>

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,6 +18,7 @@
 | `loading`        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
 | `ondark`         | `ondark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
 | `secondary`      | `secondary`      | `Boolean` | false   | Set value for secondary version of auro-button   |
+| `slim`           | `slim`           | `Boolean` | false   | Set value for slim version of auro-button        |
 | `svgIconLeft`    | `svgIconLeft`    | `String`  |         | **DEPRECATED** Use auro-icon                     |
 | `svgIconRight`   | `svgIconRight`   | `String`  |         | **DEPRECATED** Use auro-icon                     |
 | `tertiary`       | `tertiary`       | `Boolean` | false   | Set value for tertiary version of auro-button    |

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -20,6 +20,7 @@ import { isFocusVisibleSupported, isFocusVisiblePolyfillAvailable } from './util
  * @attr {Boolean} ondark - Set value for on-dark version of auro-button
  * @attr {Boolean} secondary - Set value for secondary version of auro-button
  * @attr {Boolean} tertiary - Set value for tertiary version of auro-button
+ * @attr {Boolean} slim - Set value for slim version of auro-button
  * @attr {String} arialabel - Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead.
  * @attr {String} arialabelledby - Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion.
  * @attr {String} id - Set the unique ID of an element.
@@ -40,6 +41,7 @@ class AuroButton extends LitElement {
     this.ondark = false;
     this.secondary = false;
     this.tertiary = false;
+    this.slim = false;
   }
 
   connectedCallback() {
@@ -79,6 +81,10 @@ class AuroButton extends LitElement {
         reflect: true
       },
       tertiary:         {
+        type: Boolean,
+        reflect: true
+      },
+      slim: {
         type: Boolean,
         reflect: true
       },
@@ -139,6 +145,7 @@ class AuroButton extends LitElement {
       'auro-buttonOndark--secondary': this.secondary && this.ondark,
       'auro-button--tertiary': this.tertiary,
       'auro-buttonOndark--tertiary': this.tertiary && this.ondark,
+      'auro-button--slim': this.slim,
       'icon': this.svgIconLeft || this.svgIconRight,
       'loading': this.loading
     };

--- a/src/style.scss
+++ b/src/style.scss
@@ -44,6 +44,7 @@ $auro-rgb-color-base-white-03: rgba(255, 255, 255, .03);
     border-color: var(--auro-color-ui-default-on-light);
     box-shadow: inset 0 0 0 3px var(--auro-color-ui-default-on-light);
   }
+
   // auro-buttonOndark
   &Ondark {
     background-color: var(--auro-color-ui-default-on-dark);
@@ -84,10 +85,6 @@ $auro-rgb-color-base-white-03: rgba(255, 255, 255, .03);
 // adjust alignment for slotted SVG icon
 ::slotted(svg) {
   vertical-align: middle;
-}
-
-::slotted(auro-icon) {
-  padding: 0 4px;
 }
 
 // Note: without this, events on a disabled element will still fire
@@ -379,6 +376,14 @@ slot {
         }
       }
     }
+  }
+  // auro-button--slim
+  &--slim {
+    padding: var(--auro-size-xs) var(--auro-size-md);
+    font-size: var(--auro-text-body-size-sm);
+    min-width: unset;
+    min-height: 2.25rem;
+    max-height: 2.25rem;
   }
 }
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -86,6 +86,10 @@ $auro-rgb-color-base-white-03: rgba(255, 255, 255, .03);
   vertical-align: middle;
 }
 
+::slotted(auro-icon) {
+  padding: 0 4px;
+}
+
 // Note: without this, events on a disabled element will still fire
 slot {
   pointer-events: none;
@@ -98,7 +102,7 @@ slot {
 
   position: relative;
 
-  padding: var(--auro-size-sm) var(--auro-size-lg);
+  padding: 0 var(--auro-size-lg);
 
   color: var(--auro-color-text-primary-on-dark);
   cursor: pointer;
@@ -108,12 +112,19 @@ slot {
   font-family: var(--auro-font-family-default);
   font-size: var(--auro-text-body-size-default);
   font-weight: var(--auro-text-body-default-weight);
-  line-height: var(--auro-unitless-scale-140);
   overflow: hidden;
   text-overflow: ellipsis;
   user-select: none;
   white-space: nowrap;
-  width: 100%;
+
+  min-height: var(--auro-size-xxl);
+  max-height: var(--auro-size-xxl);
+
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--auro-size-xxs);
 
   // removes margins around button in Safari
   margin: 0;


### PR DESCRIPTION
# Alaska Airlines Pull Request

Added a `slim` property to match slim tertiary button style.
Updates text and icon alignment within the button.

**Fixes:** #159 #164 

## Summary:

_Please summarize the scope of the changes you have submitted, what the intent of the work is and anything that describes the before/after state of the project._

BEFORE: 

<img width="1038" alt="Screen Shot 2022-08-24 at 6 48 34 PM" src="https://user-images.githubusercontent.com/181089/186555825-8c857978-2c7a-4202-a2eb-a196ca88be8d.png">

AFTER: 

<img width="1032" alt="Screen Shot 2022-08-24 at 6 49 33 PM" src="https://user-images.githubusercontent.com/181089/186555916-6a0dfa4f-f1bd-47be-b56a-5e327ec743c4.png">



## Type of change:

Please delete options that are not relevant.

- [x] New capability
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate)


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
