### PR TITLE
Add `loadingText` attribute and `aria-label` for loading state

### DIFF
--- a/apiExamples/loadingText.html
+++ b/apiExamples/loadingText.html
@@ -1,0 +1,1 @@
+<auro-button loading loadingText="Custom loading text">Primary</auro-button>

--- a/demo/api.md
+++ b/demo/api.md
@@ -13,13 +13,15 @@
 
 | Property         | Attribute        | Type      | Default | Description                                      |
 |------------------|------------------|-----------|---------|--------------------------------------------------|
+| [ariaexpanded](#ariaexpanded)   | `ariaexpanded`   | `Boolean` |         | Populates the `aria-expanded` attribute that indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. This is an optional attribute for buttons. |
 | [arialabel](#arialabel)      | `arialabel`      | `String`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
 | [arialabelledby](#arialabelledby) | `arialabelledby` | `String`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
 | [autofocus](#autofocus)      | `autofocus`      | `Boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
-| [disabled](#disabled)       | `disabled`       | `Boolean` | false   | If set to true button will become disabled and not allow for interactions |
+| [disabled](#disabled)       | `disabled`       | `Boolean` | false   | If set to true, button will become disabled and not allow for interactions |
 | [fluid](#fluid)          | `fluid`          | `Boolean` | false   | Alters the shape of the button to be full width of its parent container |
 | [iconOnly](#iconOnly)       | `iconOnly`       | `Boolean` | false   | If set to true, the button will contain an icon with no additional content |
 | [loading](#loading)        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
+| [loadingText](#loadingText)    | `loadingText`    | `String`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
 | [onDark](#onDark)         | `onDark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
 | [ready](#ready)          | `ready`          | `Boolean` | false   | When false the component API should not be called. |
 | [rounded](#rounded)        | `rounded`        | `Boolean` | false   | If set to true, the button will have a rounded shape |

--- a/demo/api.md
+++ b/demo/api.md
@@ -512,7 +512,7 @@ In the following example see how the `fluid` attributes alters the shape of the 
 
 ## Loading State
 
-Use the `loading` attribute to alter the content to teh shimmering dots to alert the user that the button/form is in an active state. The `loading` attribute will also place the element in a disabled state to keep the user from re-submitting an action.
+Use the `loading` attribute to alter the content to the shimmering dots to alert the user that the button/form is in an active state. The `loading` attribute will also place the element in a disabled state to keep the user from re-submitting an action.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/loading.html) -->
@@ -551,6 +551,27 @@ Use the `loading` attribute to alter the content to teh shimmering dots to alert
 <auro-button ondark loading>Primary</auro-button>
 <auro-button variant="secondary" ondark loading>Secondary</auro-button>
 <auro-button variant="tertiary" ondark loading>Tertiary</auro-button>
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
+### Loading text
+
+To provide a custom loading message for assistive technologies, use the `loadingText` attribute. If not provided, the default message will be "Loading...".
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/loadingText.html) -->
+  <!-- The below content is automatically added from ./../apiExamples/loadingText.html -->
+  <auro-button loading loadingText="Custom loading text">Primary</auro-button>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/loadingText.html) -->
+<!-- The below code snippet is automatically added from ./../apiExamples/loadingText.html -->
+
+```html
+<auro-button loading loadingText="Custom loading text">Primary</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,13 +10,15 @@
 
 | Property         | Attribute        | Type      | Default | Description                                      |
 |------------------|------------------|-----------|---------|--------------------------------------------------|
+| `ariaexpanded`   | `ariaexpanded`   | `Boolean` |         | Populates the `aria-expanded` attribute that indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. This is an optional attribute for buttons. |
 | `arialabel`      | `arialabel`      | `String`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
 | `arialabelledby` | `arialabelledby` | `String`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
 | `autofocus`      | `autofocus`      | `Boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
-| `disabled`       | `disabled`       | `Boolean` | false   | If set to true button will become disabled and not allow for interactions |
+| `disabled`       | `disabled`       | `Boolean` | false   | If set to true, button will become disabled and not allow for interactions |
 | `fluid`          | `fluid`          | `Boolean` | false   | Alters the shape of the button to be full width of its parent container |
 | `iconOnly`       | `iconOnly`       | `Boolean` | false   | If set to true, the button will contain an icon with no additional content |
 | `loading`        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
+| `loadingText`    | `loadingText`    | `String`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
 | `onDark`         | `onDark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
 | `ready`          | `ready`          | `Boolean` | false   | When false the component API should not be called. |
 | `rounded`        | `rounded`        | `Boolean` | false   | If set to true, the button will have a rounded shape |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -254,7 +254,7 @@ In the following example see how the `fluid` attributes alters the shape of the 
 
 ## Loading State
 
-Use the `loading` attribute to alter the content to teh shimmering dots to alert the user that the button/form is in an active state. The `loading` attribute will also place the element in a disabled state to keep the user from re-submitting an action.
+Use the `loading` attribute to alter the content to the shimmering dots to alert the user that the button/form is in an active state. The `loading` attribute will also place the element in a disabled state to keep the user from re-submitting an action.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/loading.html) -->
@@ -278,6 +278,23 @@ Use the `loading` attribute to alter the content to teh shimmering dots to alert
   <span slot="trigger">See code</span>
 
 <!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/loadingOnDark.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+### Loading text
+
+To provide a custom loading message for assistive technologies, use the `loadingText` attribute. If not provided, the default message will be "Loading...".
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/loadingText.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/loadingText.html) -->
 <!-- AURO-GENERATED-CONTENT:END -->
 
 </auro-accordion>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-button",
-  "version": "9.0.0",
+  "version": "9.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-button",
-      "version": "9.0.0",
+      "version": "9.1.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "build:release": "npm-run-all build build:test types postinstall",
     "build:ci": "npm-run-all sweep build:release",
     "build:sass": "npm-run-all build:sass:component postCss:component sass:render",
-    "build:api": "wca analyze 'src/auro-button.js' --outFiles docs/api.md",
+    "build:api": "wca analyze 'scripts/wca/*' --outFiles docs/api.md",
     "build:docs": "node ./node_modules/@aurodesignsystem/auro-library/scripts/build/generateDocs.mjs",
     "build:dev:assets": "npm-run-all build:sass:component postCss:component sass:render postversion",
     "build:watch": "nodemon -e scss,js,html --watch src --watch apiExamples --watch docs --exec npm run build:dev:assets",

--- a/scripts/wca/auro-button.js
+++ b/scripts/wca/auro-button.js
@@ -1,0 +1,9 @@
+
+import { AuroButton } from '../../src/auro-button.js';
+
+/** */
+class AuroButtonWCA extends AuroButton {}
+
+if (!customElements.get("auro-button")) {
+  customElements.define("auro-button", AuroButtonWCA);
+}

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // Copyright (c) Alaska Air. All right reserved. Licensed under the Apache-2.0 license
 // See LICENSE in the project root for license information.
 
@@ -24,7 +25,7 @@ import loaderVersion from './loaderVersion.js';
  * @attr {Boolean} disabled - If set to true, button will become disabled and not allow for interactions
  * @attr {Boolean} iconOnly - If set to true, the button will contain an icon with no additional content
  * @attr {Boolean} loading - If set to true button text will be replaced with `auro-loader` and become disabled
- * @attr {String} loadingText - Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value will be used.
+ * @attr {String} loadingText - Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used.
  * @attr {Boolean} onDark - Set value for on-dark version of auro-button
  * @attr {Boolean} rounded - If set to true, the button will have a rounded shape
  * @attr {Boolean} slim - Set value for slim version of auro-button
@@ -138,8 +139,7 @@ export class AuroButton extends LitElement {
         reflect: true
       },
       loadingText:      {
-        type: String,
-        reflect: true
+        type: String
       },
       onDark:           {
         type: Boolean,
@@ -236,12 +236,22 @@ export class AuroButton extends LitElement {
     this.notifyReady();
   }
 
+  /**
+   * Submits the form that this button is associated with.
+   * @private
+   * @returns {void}
+   */
   surfaceSubmitEvent() {
     if (this.form) {
       this.form.requestSubmit();
     }
   }
 
+  /**
+   * Returns the form element that this button is associated with.
+   * @private
+   * @returns {HTMLFormElement|null}
+   */
   get form() {
     return this.internals ? this.internals.form : null;
   }

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -21,9 +21,10 @@ import loaderVersion from './loaderVersion.js';
 
 /**
  * @attr {Boolean} autofocus - This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user
- * @attr {Boolean} disabled - If set to true button will become disabled and not allow for interactions
+ * @attr {Boolean} disabled - If set to true, button will become disabled and not allow for interactions
  * @attr {Boolean} iconOnly - If set to true, the button will contain an icon with no additional content
  * @attr {Boolean} loading - If set to true button text will be replaced with `auro-loader` and become disabled
+ * @attr {String} loadingText - Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value will be used.
  * @attr {Boolean} onDark - Set value for on-dark version of auro-button
  * @attr {Boolean} rounded - If set to true, the button will have a rounded shape
  * @attr {Boolean} slim - Set value for slim version of auro-button
@@ -75,6 +76,7 @@ export class AuroButton extends LitElement {
     this.rounded = false;
     this.slim = false;
     this.fluid = false;
+    this.loadingText = this.loadingText || 'Loading...';
 
     // Support for HTML5 forms
     if (typeof this.attachInternals === 'function') {
@@ -133,6 +135,10 @@ export class AuroButton extends LitElement {
       },
       loading:          {
         type: Boolean,
+        reflect: true
+      },
+      loadingText:      {
+        type: String,
         reflect: true
       },
       onDark:           {
@@ -255,7 +261,7 @@ export class AuroButton extends LitElement {
     return html`
       <button
         part="button"
-        aria-label="${ifDefined(this.arialabel ? this.arialabel : undefined)}"
+        aria-label="${ifDefined(this.loading ? this.loadingText : this.arialabel || undefined)}"
         aria-labelledby="${ifDefined(this.arialabelledby ? this.arialabelledby : undefined)}"
         aria-expanded="${ifDefined(this.ariaexpanded)}"
         ?autofocus="${this.autofocus}"

--- a/test/auro-button.test.js
+++ b/test/auro-button.test.js
@@ -143,6 +143,28 @@ describe('auro-button', () => {
     expect(button.getAttribute('aria-label')).to.equal('label');
   });
 
+  it('tests that button in loading state has proper aria-label', async () => {
+    const el = await fixture(html`
+      <auro-button loading>Click Me!</auro-button>
+    `);
+
+    const root = el.shadowRoot;
+    const button = root.querySelector('button');
+
+    expect(button.getAttribute('aria-label')).to.equal(el.loadingText);
+  });
+
+  it('tests setting custom loading text on button in loading state', async () => {
+    const el = await fixture(html`
+      <auro-button loading loadingText="cargando">Click Me!</auro-button>
+    `);
+
+    const root = el.shadowRoot;
+    const button = root.querySelector('button');
+
+    expect(button.getAttribute('aria-label')).to.equal(el.loadingText);
+  });
+
   it('tests setting arialabelledby', async () => {
     const el = await fixture(html`
       <auro-button arialabelledby='me'>Click Me!</auro-button>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add support for custom loading text and improve accessibility for buttons in loading state

New Features:
- Add `loadingText` attribute to allow custom loading text for assistive technologies
- Implement dynamic `aria-label` for buttons in loading state

Enhancements:
- Improve accessibility by providing a default and customizable loading text
- Update documentation to explain the new `loadingText` attribute

Tests:
- Add test cases for loading state aria-label and custom loading text