### PR TITLE
feat: add `ariahidden` and `tIndex` attrs #319

### DIFF
--- a/demo/api.md
+++ b/demo/api.md
@@ -15,11 +15,10 @@
 | [disabled](#disabled)       | `disabled`       | `boolean` | false   | If set to true, button will become disabled and not allow for interactions. |
 | [fluid](#fluid)          | `fluid`          | `boolean` | false   | Alters the shape of the button to be full width of its parent container. |
 | [iconOnly](#iconOnly)       | `iconOnly`       | `boolean` | false   | If set to true, the button will contain an icon with no additional content. |
-| [id](#id)             | `id`             | `string`  |         | Set the unique ID of an element.                 |
 | [loading](#loading)        | `loading`        | `boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled. |
 | [loadingText](#loadingText)    | `loadingText`    | `string`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
 | [onDark](#onDark)         | `onDark`         | `boolean` | false   | Set value for on-dark version of auro-button.    |
-| [ready](#ready)          | `ready`          | `Boolean` | false   | When false the component API should not be called. |
+| [ready](#ready)          | `ready`          | `boolean` |         |                                                  |
 | [rounded](#rounded)        | `rounded`        | `boolean` | false   | If set to true, the button will have a rounded shape. |
 | [secondary](#secondary)      | `secondary`      | `boolean` | false   | DEPRECATED.                                      |
 | [slim](#slim)           | `slim`           | `boolean` | false   | Set value for slim version of auro-button.       |
@@ -29,12 +28,6 @@
 | [type](#type)           | `type`           | `string`  |         | The type of the button. Possible values are: `submit`, `reset`, `button`. |
 | [value](#value)          | `value`          | `string`  |         | Defines the value associated with the button which is submitted with the form data. |
 | [variant](#variant)        | `variant`        | `string`  |         | Sets button variant option. Possible values are: `secondary`, `tertiary`. |
-
-## Events
-
-| Event              | Type               | Description                                      |
-|--------------------|--------------------|--------------------------------------------------|
-| `auroButton-ready` | `CustomEvent<any>` | Notifies that the component has finished initializing. |
 
 ## Slots
 
@@ -575,8 +568,8 @@ To provide a custom loading message for assistive technologies, use the `loading
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
 
-## ARIA tags
-Instead of using `aria-*` tag, use `aria*` (without the hyphen) to properly bind ARIA tags.
+## ARIA attributes
+Instead of using `aria-*` attributes, use `aria*` (without the hyphen) to properly bind ARIA attributes.
 
 For `tabindex`, use `tIndex` instead to avoid duplicated focus interaction.
 

--- a/demo/api.md
+++ b/demo/api.md
@@ -3,35 +3,32 @@
 
 # auro-button
 
-## Attributes
-
-| Attribute | Type     | Description                      |
-|-----------|----------|----------------------------------|
-| [id](#id)      | `String` | Set the unique ID of an element. |
-
 ## Properties
 
 | Property         | Attribute        | Type      | Default | Description                                      |
 |------------------|------------------|-----------|---------|--------------------------------------------------|
-| [ariaexpanded](#ariaexpanded)   | `ariaexpanded`   | `Boolean` |         | Populates the `aria-expanded` attribute that indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. This is an optional attribute for buttons. |
-| [arialabel](#arialabel)      | `arialabel`      | `String`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
-| [arialabelledby](#arialabelledby) | `arialabelledby` | `String`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
-| [autofocus](#autofocus)      | `autofocus`      | `Boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
-| [disabled](#disabled)       | `disabled`       | `Boolean` | false   | If set to true, button will become disabled and not allow for interactions |
-| [fluid](#fluid)          | `fluid`          | `Boolean` | false   | Alters the shape of the button to be full width of its parent container |
-| [iconOnly](#iconOnly)       | `iconOnly`       | `Boolean` | false   | If set to true, the button will contain an icon with no additional content |
-| [loading](#loading)        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
-| [loadingText](#loadingText)    | `loadingText`    | `String`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
-| [onDark](#onDark)         | `onDark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
+| [ariaexpanded](#ariaexpanded)   | `ariaexpanded`   | `boolean` |         | Populates the `aria-expanded` attribute that indicates whether the element,<br />or another grouping element it controls, is currently expanded or collapsed.<br />This is an optional attribute for buttons. |
+| [ariahidden](#ariahidden)     | `ariahidden`     | `string`  |         | Populates the `aria-hidden` attribute to hide the button from a11y API. |
+| [arialabel](#arialabel)      | `arialabel`      | `string`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element.<br />Use it in cases where a text label is not visible on the screen.<br />If there is visible text labeling the element, use `aria-labelledby` instead. |
+| [arialabelledby](#arialabelledby) | `arialabelledby` | `string`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s),<br />and its value should be one or more element IDs, which refer to elements that have the text needed for labeling.<br />List multiple element IDs in a space delimited fashion. |
+| [autofocus](#autofocus)      | `autofocus`      | `boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user. |
+| [disabled](#disabled)       | `disabled`       | `boolean` | false   | If set to true, button will become disabled and not allow for interactions. |
+| [fluid](#fluid)          | `fluid`          | `boolean` | false   | Alters the shape of the button to be full width of its parent container. |
+| [iconOnly](#iconOnly)       | `iconOnly`       | `boolean` | false   | If set to true, the button will contain an icon with no additional content. |
+| [id](#id)             | `id`             | `string`  |         | Set the unique ID of an element.                 |
+| [loading](#loading)        | `loading`        | `boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled. |
+| [loadingText](#loadingText)    | `loadingText`    | `string`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
+| [onDark](#onDark)         | `onDark`         | `boolean` | false   | Set value for on-dark version of auro-button.    |
 | [ready](#ready)          | `ready`          | `Boolean` | false   | When false the component API should not be called. |
-| [rounded](#rounded)        | `rounded`        | `Boolean` | false   | If set to true, the button will have a rounded shape |
-| [secondary](#secondary)      | `secondary`      | `Boolean` | false   | DEPRECATED                                       |
-| [slim](#slim)           | `slim`           | `Boolean` | false   | Set value for slim version of auro-button        |
-| [tertiary](#tertiary)       | `tertiary`       | `Boolean` | false   | DEPRECATED                                       |
-| [title](#title)          | `title`          | `String`  |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
-| [type](#type)           | `type`           | `String`  |         | The type of the button. Possible values are: `submit`, `reset`, `button` |
-| [value](#value)          | `value`          | `String`  |         | Defines the value associated with the button which is submitted with the form data. |
-| [variant](#variant)        | `variant`        | `String`  |         | Sets button variant option. Possible values are: `secondary`, `tertiary` |
+| [rounded](#rounded)        | `rounded`        | `boolean` | false   | If set to true, the button will have a rounded shape. |
+| [secondary](#secondary)      | `secondary`      | `boolean` | false   | DEPRECATED.                                      |
+| [slim](#slim)           | `slim`           | `boolean` | false   | Set value for slim version of auro-button.       |
+| [tIndex](#tIndex)         | `tIndex`         | `string`  |         | Populates `tabIndex` to define the focusable sequence in keyboard navigation. |
+| [tertiary](#tertiary)       | `tertiary`       | `boolean` | false   | DEPRECATED.                                      |
+| [title](#title)          | `title`          | `string`  |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
+| [type](#type)           | `type`           | `string`  |         | The type of the button. Possible values are: `submit`, `reset`, `button`. |
+| [value](#value)          | `value`          | `string`  |         | Defines the value associated with the button which is submitted with the form data. |
+| [variant](#variant)        | `variant`        | `string`  |         | Sets button variant option. Possible values are: `secondary`, `tertiary`. |
 
 ## Events
 
@@ -577,6 +574,11 @@ To provide a custom loading message for assistive technologies, use the `loading
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
+
+## ARIA tags
+Instead of using `aria-*` tag, use `aria*` (without the hyphen) to properly bind ARIA tags.
+
+For `tabindex`, use `tIndex` instead to avoid duplicated focus interaction.
 
 ## Theme Support
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,34 +1,31 @@
 # auro-button
 
-## Attributes
-
-| Attribute | Type     | Description                      |
-|-----------|----------|----------------------------------|
-| `id`      | `String` | Set the unique ID of an element. |
-
 ## Properties
 
 | Property         | Attribute        | Type      | Default | Description                                      |
 |------------------|------------------|-----------|---------|--------------------------------------------------|
-| `ariaexpanded`   | `ariaexpanded`   | `Boolean` |         | Populates the `aria-expanded` attribute that indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. This is an optional attribute for buttons. |
-| `arialabel`      | `arialabel`      | `String`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead. |
-| `arialabelledby` | `arialabelledby` | `String`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion. |
-| `autofocus`      | `autofocus`      | `Boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user |
-| `disabled`       | `disabled`       | `Boolean` | false   | If set to true, button will become disabled and not allow for interactions |
-| `fluid`          | `fluid`          | `Boolean` | false   | Alters the shape of the button to be full width of its parent container |
-| `iconOnly`       | `iconOnly`       | `Boolean` | false   | If set to true, the button will contain an icon with no additional content |
-| `loading`        | `loading`        | `Boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled |
-| `loadingText`    | `loadingText`    | `String`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
-| `onDark`         | `onDark`         | `Boolean` | false   | Set value for on-dark version of auro-button     |
+| `ariaexpanded`   | `ariaexpanded`   | `boolean` |         | Populates the `aria-expanded` attribute that indicates whether the element,<br />or another grouping element it controls, is currently expanded or collapsed.<br />This is an optional attribute for buttons. |
+| `ariahidden`     | `ariahidden`     | `string`  |         | Populates the `aria-hidden` attribute to hide the button from a11y API. |
+| `arialabel`      | `arialabel`      | `string`  |         | Populates the `aria-label` attribute that is used to define a string that labels the current element.<br />Use it in cases where a text label is not visible on the screen.<br />If there is visible text labeling the element, use `aria-labelledby` instead. |
+| `arialabelledby` | `arialabelledby` | `string`  |         | Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s),<br />and its value should be one or more element IDs, which refer to elements that have the text needed for labeling.<br />List multiple element IDs in a space delimited fashion. |
+| `autofocus`      | `autofocus`      | `boolean` | false   | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user. |
+| `disabled`       | `disabled`       | `boolean` | false   | If set to true, button will become disabled and not allow for interactions. |
+| `fluid`          | `fluid`          | `boolean` | false   | Alters the shape of the button to be full width of its parent container. |
+| `iconOnly`       | `iconOnly`       | `boolean` | false   | If set to true, the button will contain an icon with no additional content. |
+| `id`             | `id`             | `string`  |         | Set the unique ID of an element.                 |
+| `loading`        | `loading`        | `boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled. |
+| `loadingText`    | `loadingText`    | `string`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
+| `onDark`         | `onDark`         | `boolean` | false   | Set value for on-dark version of auro-button.    |
 | `ready`          | `ready`          | `Boolean` | false   | When false the component API should not be called. |
-| `rounded`        | `rounded`        | `Boolean` | false   | If set to true, the button will have a rounded shape |
-| `secondary`      | `secondary`      | `Boolean` | false   | DEPRECATED                                       |
-| `slim`           | `slim`           | `Boolean` | false   | Set value for slim version of auro-button        |
-| `tertiary`       | `tertiary`       | `Boolean` | false   | DEPRECATED                                       |
-| `title`          | `title`          | `String`  |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
-| `type`           | `type`           | `String`  |         | The type of the button. Possible values are: `submit`, `reset`, `button` |
-| `value`          | `value`          | `String`  |         | Defines the value associated with the button which is submitted with the form data. |
-| `variant`        | `variant`        | `String`  |         | Sets button variant option. Possible values are: `secondary`, `tertiary` |
+| `rounded`        | `rounded`        | `boolean` | false   | If set to true, the button will have a rounded shape. |
+| `secondary`      | `secondary`      | `boolean` | false   | DEPRECATED.                                      |
+| `slim`           | `slim`           | `boolean` | false   | Set value for slim version of auro-button.       |
+| `tIndex`         | `tIndex`         | `string`  |         | Populates `tabIndex` to define the focusable sequence in keyboard navigation. |
+| `tertiary`       | `tertiary`       | `boolean` | false   | DEPRECATED.                                      |
+| `title`          | `title`          | `string`  |         | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
+| `type`           | `type`           | `string`  |         | The type of the button. Possible values are: `submit`, `reset`, `button`. |
+| `value`          | `value`          | `string`  |         | Defines the value associated with the button which is submitted with the form data. |
+| `variant`        | `variant`        | `string`  |         | Sets button variant option. Possible values are: `secondary`, `tertiary`. |
 
 ## Events
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,11 +12,10 @@
 | `disabled`       | `disabled`       | `boolean` | false   | If set to true, button will become disabled and not allow for interactions. |
 | `fluid`          | `fluid`          | `boolean` | false   | Alters the shape of the button to be full width of its parent container. |
 | `iconOnly`       | `iconOnly`       | `boolean` | false   | If set to true, the button will contain an icon with no additional content. |
-| `id`             | `id`             | `string`  |         | Set the unique ID of an element.                 |
 | `loading`        | `loading`        | `boolean` | false   | If set to true button text will be replaced with `auro-loader` and become disabled. |
 | `loadingText`    | `loadingText`    | `string`  |         | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
 | `onDark`         | `onDark`         | `boolean` | false   | Set value for on-dark version of auro-button.    |
-| `ready`          | `ready`          | `Boolean` | false   | When false the component API should not be called. |
+| `ready`          | `ready`          | `boolean` |         |                                                  |
 | `rounded`        | `rounded`        | `boolean` | false   | If set to true, the button will have a rounded shape. |
 | `secondary`      | `secondary`      | `boolean` | false   | DEPRECATED.                                      |
 | `slim`           | `slim`           | `boolean` | false   | Set value for slim version of auro-button.       |
@@ -26,12 +25,6 @@
 | `type`           | `type`           | `string`  |         | The type of the button. Possible values are: `submit`, `reset`, `button`. |
 | `value`          | `value`          | `string`  |         | Defines the value associated with the button which is submitted with the form data. |
 | `variant`        | `variant`        | `string`  |         | Sets button variant option. Possible values are: `secondary`, `tertiary`. |
-
-## Events
-
-| Event              | Type               | Description                                      |
-|--------------------|--------------------|--------------------------------------------------|
-| `auroButton-ready` | `CustomEvent<any>` | Notifies that the component has finished initializing. |
 
 ## Slots
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -299,6 +299,14 @@ To provide a custom loading message for assistive technologies, use the `loading
 
 </auro-accordion>
 
+
+## ARIA tags
+Instead of using `aria-*` tag, use `aria*` (without the hyphen) to properly bind ARIA tags.
+
+For `tabindex`, use `tIndex` instead to avoid duplicated focus interaction.
+
+
+
 ## Theme Support
 
 The component may be restyled using the following code sample and changing the values of the following token(s).

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -300,8 +300,8 @@ To provide a custom loading message for assistive technologies, use the `loading
 </auro-accordion>
 
 
-## ARIA tags
-Instead of using `aria-*` tag, use `aria*` (without the hyphen) to properly bind ARIA tags.
+## ARIA attributes
+Instead of using `aria-*` attributes, use `aria*` (without the hyphen) to properly bind ARIA attributes.
 
 For `tabindex`, use `tIndex` instead to avoid duplicated focus interaction.
 

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -21,8 +21,6 @@ import { AuroLoader } from '@aurodesignsystem/auro-loader/src/auro-loader.js';
 import loaderVersion from './loaderVersion.js';
 
 /**
- * @prop {Boolean} ready - When false the component API should not be called.
- * @event auroButton-ready - Notifies that the component has finished initializing.
  * @slot - Default slot for the text of the button.
  * @slot icon - Slot to provide auro-icon for the button.
  * @csspart button - Apply CSS to HTML5 button.
@@ -51,7 +49,6 @@ export class AuroButton extends LitElement {
     this.iconOnly = false;
     this.loading = false;
     this.onDark = false;
-    this.ready = false;
     this.secondary = false;
     this.tertiary = false;
     this.rounded = false;
@@ -189,14 +186,6 @@ export class AuroButton extends LitElement {
       },
 
       /**
-       * Set the unique ID of an element.
-       */
-      id: {
-        type: String,
-        reflect: true
-      },
-
-      /**
        * Populates the `aria-hidden` attribute to hide the button from a11y API.
        */
       ariahidden: {
@@ -290,21 +279,6 @@ export class AuroButton extends LitElement {
     this.renderRoot.querySelector('button').focus();
   }
 
-  /**
-   *  Marks the component as ready and sends event.
-   * @private
-   * @returns {void}
-   */
-  notifyReady() {
-    this.ready = true;
-
-    this.dispatchEvent(new CustomEvent('auroButton-ready', {
-      bubbles: true,
-      cancelable: false,
-      composed: true,
-    }));
-  }
-
   updated() {
     // support the old `secondary` and `tertiary` attributes` that are deprecated
     if (this.secondary) {
@@ -314,10 +288,6 @@ export class AuroButton extends LitElement {
     if (this.tertiary) {
       this.setAttribute('variant', 'tertiary');
     }
-  }
-
-  firstUpdated() {
-    this.notifyReady();
   }
 
   /**
@@ -355,7 +325,7 @@ export class AuroButton extends LitElement {
     return html`
       <button
         part="button"
-        aria-hidden="${ifDefined(this.ariahidden ? this.ariahidden : undefined)}"
+        aria-hidden="${ifDefined(this.ariahidden || undefined)}"
         aria-label="${ifDefined(this.loading ? this.loadingText : this.arialabel || undefined)}"
         aria-labelledby="${ifDefined(this.arialabelledby ? this.arialabelledby : undefined)}"
         aria-expanded="${ifDefined(this.ariaexpanded)}"

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -21,25 +21,6 @@ import { AuroLoader } from '@aurodesignsystem/auro-loader/src/auro-loader.js';
 import loaderVersion from './loaderVersion.js';
 
 /**
- * @attr {Boolean} autofocus - This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user
- * @attr {Boolean} disabled - If set to true, button will become disabled and not allow for interactions
- * @attr {Boolean} iconOnly - If set to true, the button will contain an icon with no additional content
- * @attr {Boolean} loading - If set to true button text will be replaced with `auro-loader` and become disabled
- * @attr {String} loadingText - Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used.
- * @attr {Boolean} onDark - Set value for on-dark version of auro-button
- * @attr {Boolean} rounded - If set to true, the button will have a rounded shape
- * @attr {Boolean} slim - Set value for slim version of auro-button
- * @attr {Boolean} fluid - Alters the shape of the button to be full width of its parent container
- * @attr {String} arialabel - Populates the `aria-label` attribute that is used to define a string that labels the current element. Use it in cases where a text label is not visible on the screen. If there is visible text labeling the element, use `aria-labelledby` instead.
- * @attr {String} arialabelledby - Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s), and its value should be one or more element IDs, which refer to elements that have the text needed for labeling. List multiple element IDs in a space delimited fashion.
- * @attr {Boolean} ariaexpanded - Populates the `aria-expanded` attribute that indicates whether the element, or another grouping element it controls, is currently expanded or collapsed. This is an optional attribute for buttons.
- * @attr {String} id - Set the unique ID of an element.
- * @attr {String} title - Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element.
- * @attr {String} type - The type of the button. Possible values are: `submit`, `reset`, `button`
- * @attr {String} value - Defines the value associated with the button which is submitted with the form data.
- * @attr {String} variant - Sets button variant option. Possible values are: `secondary`, `tertiary`
- * @attr {Boolean} secondary - DEPRECATED
- * @attr {Boolean} tertiary - DEPRECATED
  * @prop {Boolean} ready - When false the component API should not be called.
  * @event auroButton-ready - Notifies that the component has finished initializing.
  * @slot - Default slot for the text of the button.
@@ -65,7 +46,6 @@ export class AuroButton extends LitElement {
 
   constructor() {
     super();
-
     this.autofocus = false;
     this.disabled = false;
     this.iconOnly = false;
@@ -110,73 +90,177 @@ export class AuroButton extends LitElement {
 
   static get properties() {
     return {
+
+      /**
+       * This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user.
+       */
       autofocus:        {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * If set to true, button will become disabled and not allow for interactions.
+       */
       disabled:         {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * DEPRECATED.
+       * @deprecated
+       */
       secondary:         {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * DEPRECATED.
+       * @deprecated
+       */
       tertiary:         {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * Alters the shape of the button to be full width of its parent container.
+       */
       fluid:         {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * If set to true, the button will contain an icon with no additional content.
+       */
       iconOnly: {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * If set to true button text will be replaced with `auro-loader` and become disabled.
+       */
       loading:          {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used.
+       */
       loadingText:      {
         type: String
       },
+
+      /**
+       * Set value for on-dark version of auro-button.
+       */
       onDark:           {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * If set to true, the button will have a rounded shape.
+       */
       rounded: {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * Set value for slim version of auro-button.
+       */
       slim: {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * Populates `tabIndex` to define the focusable sequence in keyboard navigation.
+       */
+      tIndex: {
+        type: String,
+        reflect: true
+      },
+
+      /**
+       * Set the unique ID of an element.
+       */
+      id: {
+        type: String,
+        reflect: true
+      },
+
+      /**
+       * Populates the `aria-hidden` attribute to hide the button from a11y API.
+       */
+      ariahidden: {
+        type: String,
+        reflect: true,
+      },
+
+      /**
+       * Populates the `aria-label` attribute that is used to define a string that labels the current element.
+       * Use it in cases where a text label is not visible on the screen.
+       * If there is visible text labeling the element, use `aria-labelledby` instead.
+       */
       arialabel:        {
         type: String,
         reflect: true
       },
+
+      /**
+       * Populates the `aria-labelledby` attribute that establishes relationships between objects and their label(s),
+       * and its value should be one or more element IDs, which refer to elements that have the text needed for labeling.
+       * List multiple element IDs in a space delimited fashion.
+       */
       arialabelledby:   {
         type: String,
         reflect: true
       },
+
+      /**
+       * Populates the `aria-expanded` attribute that indicates whether the element,
+       * or another grouping element it controls, is currently expanded or collapsed.
+       * This is an optional attribute for buttons.
+       */
       ariaexpanded: {
         type: Boolean,
         reflect: true
       },
+
+      /**
+       * Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element.
+       */
       title:            {
         type: String,
         reflect: true
       },
+
+      /**
+       * The type of the button. Possible values are: `submit`, `reset`, `button`.
+       */
       type:             {
         type: String,
         reflect: true
       },
+
+      /**
+       * Defines the value associated with the button which is submitted with the form data.
+       */
       value:            {
         type: String,
         reflect: true
       },
+
+      /**
+       * Sets button variant option. Possible values are: `secondary`, `tertiary`.
+       */
       variant:          {
         type: String,
         reflect: true
@@ -271,9 +355,11 @@ export class AuroButton extends LitElement {
     return html`
       <button
         part="button"
+        aria-hidden="${ifDefined(this.ariahidden ? this.ariahidden : undefined)}"
         aria-label="${ifDefined(this.loading ? this.loadingText : this.arialabel || undefined)}"
         aria-labelledby="${ifDefined(this.arialabelledby ? this.arialabelledby : undefined)}"
         aria-expanded="${ifDefined(this.ariaexpanded)}"
+        tabIndex="${ifDefined(this.tIndex)}"
         ?autofocus="${this.autofocus}"
         class="${classMap(classes)}"
         ?disabled="${this.disabled || this.loading}"

--- a/test/auro-button.test.js
+++ b/test/auro-button.test.js
@@ -226,6 +226,23 @@ describe('auro-button', () => {
     await expect(el).to.be.accessible();
   });
 
+  it(`auro-button is accessible with various ARIA attrs`, async () => {
+    const el = await fixture(html`
+      <div>
+        <auro-button tIndex="-1" ariahidden="true">Click Me!</auro-button>
+        <auro-button arialabel="This is a button">Click Me!</auro-button>
+        <auro-button ariaexpanded="true">Click Me!</auro-button>
+      </div>
+    `);
+
+    await expect(el.children[0].shadowRoot.querySelector('button')).to.have.attribute('tabindex', '-1');
+    await expect(el.children[0].shadowRoot.querySelector('button')).to.have.attribute('aria-hidden', 'true');
+    await expect(el.children[1].shadowRoot.querySelector('button')).to.have.attribute('aria-label', 'This is a button');
+    await expect(el.children[2].shadowRoot.querySelector('button')).to.have.attribute('aria-expanded', 'true');
+
+    await expect(el).to.be.accessible();
+  });
+
   it('auro-button custom element is defined', async () => {
     const el = await Boolean(customElements.get("auro-button"));
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

add props for `aria-hidden` and `tabIndex`


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add ariahidden and tIndex attributes to the AuroButton component, bind them in the template for improved accessibility, and update documentation to reflect the new properties and ARIA usage guidelines.

New Features:
- Add tIndex property to control the tabindex attribute on the button
- Add ariahidden property to control the aria-hidden attribute on the button

Documentation:
- Update API documentation to include ariahidden and tIndex properties and add ARIA tags usage guidelines