### PR TITLE
refactor: remove `icon` slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ import "@aurodesignsystem/auro-button";
 <auro-button>Primary</auro-button>
 <auro-button variant="secondary">Secondary</auro-button>
 <auro-button variant="tertiary">Tertiary</auro-button>
+<auro-button variant="ghost">Ghost</auro-button>
 <auro-button variant="flat">Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -139,6 +140,7 @@ The auro-button element should be used in situations where users may:
 <auro-button>Primary</auro-button>
 <auro-button variant="secondary">Secondary</auro-button>
 <auro-button variant="tertiary">Tertiary</auro-button>
+<auro-button variant="ghost">Ghost</auro-button>
 <auro-button variant="flat">Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/apiExamples/basic.html
+++ b/apiExamples/basic.html
@@ -1,4 +1,5 @@
 <auro-button>Primary</auro-button>
 <auro-button variant="secondary">Secondary</auro-button>
 <auro-button variant="tertiary">Tertiary</auro-button>
+<auro-button variant="ghost">Ghost</auro-button>
 <auro-button variant="flat">Flat</auro-button>

--- a/apiExamples/disabled.html
+++ b/apiExamples/disabled.html
@@ -1,3 +1,5 @@
 <auro-button disabled>Primary</auro-button>
 <auro-button variant="secondary" disabled>Secondary</auro-button>
 <auro-button variant="tertiary" disabled>Tertiary</auro-button>
+<auro-button variant="ghost" disabled>Ghost</auro-button>
+<auro-button variant="flat" disabled>Flat</auro-button>

--- a/apiExamples/disabledOnDark.html
+++ b/apiExamples/disabledOnDark.html
@@ -1,3 +1,5 @@
 <auro-button disabled ondark>Primary</auro-button>
 <auro-button variant="secondary" disabled ondark>Secondary</auro-button>
 <auro-button variant="tertiary" disabled ondark>Tertiary</auro-button>
+<auro-button variant="ghost" disabled ondark>Ghost</auro-button>
+<auro-button variant="flat" disabled ondark>Flat</auro-button>

--- a/apiExamples/fluid.html
+++ b/apiExamples/fluid.html
@@ -1,3 +1,5 @@
 <auro-button fluid>Primary</auro-button>
 <auro-button variant="secondary" fluid>Secondary</auro-button>
 <auro-button variant="tertiary" fluid>Tertiary</auro-button>
+<auro-button variant="ghost" fluid>Ghost</auro-button>
+<auro-button variant="flat" fluid>Flat</auro-button>

--- a/apiExamples/icon.html
+++ b/apiExamples/icon.html
@@ -1,12 +1,12 @@
 <auro-button arialabel="wifi">
-  Activate WiFi
-  <auro-icon customColor category="in-flight" name="wifi" slot="icon"></auro-icon>
+  <span>Activate WiFi</span>
+  <auro-icon customColor category="in-flight" name="wifi"></auro-icon>
 </auro-button>
 <auro-button variant="secondary" arialabel="arrow-left">
-  Previous action
-  <auro-icon customcolor category="interface" name="arrow-left" slot="icon"></auro-icon>
+  <span>Previous action</span>
+  <auro-icon customcolor category="interface" name="arrow-left" ></auro-icon>
 </auro-button>
 <auro-button variant="tertiary" arialabel="heart-filled">
-  Love this ...
-  <auro-icon customcolor category="interface" name="heart-filled" slot="icon"></auro-icon>
+  <span>Love this ...</span>
+  <auro-icon customcolor category="interface" name="heart-filled" ></auro-icon>
 </auro-button>

--- a/apiExamples/iconOnlySlim.html
+++ b/apiExamples/iconOnlySlim.html
@@ -1,9 +1,9 @@
 <auro-button arialabel="home-filled" iconOnly slim>
-  <auro-icon customColor category="interface" name="home-filled" slot="icon"></auro-icon>
+  <auro-icon customColor category="interface" name="home-filled"></auro-icon>
 </auro-button>
 <auro-button arialabel="arrow-left" variant="secondary" iconOnly slim>
-  <auro-icon customColor category="interface" name="arrow-left" slot="icon"></auro-icon>
+  <auro-icon customColor category="interface" name="arrow-left"></auro-icon>
 </auro-button>
 <auro-button arialabel="heart-filled" variant="tertiary" iconOnly slim>
-  <auro-icon customColor category="interface" name="heart-filled" slot="icon"></auro-icon>
+  <auro-icon customColor category="interface" name="heart-filled"></auro-icon>
 </auro-button>

--- a/apiExamples/loading.html
+++ b/apiExamples/loading.html
@@ -1,3 +1,5 @@
 <auro-button loading>Primary</auro-button>
 <auro-button variant="secondary" loading>Secondary</auro-button>
 <auro-button variant="tertiary" loading>Tertiary</auro-button>
+<auro-button variant="ghost" loading>Ghost</auro-button>
+<auro-button variant="flat" loading>Flat</auro-button>

--- a/apiExamples/loadingOnDark.html
+++ b/apiExamples/loadingOnDark.html
@@ -1,3 +1,5 @@
 <auro-button ondark loading>Primary</auro-button>
 <auro-button variant="secondary" ondark loading>Secondary</auro-button>
 <auro-button variant="tertiary" ondark loading>Tertiary</auro-button>
+<auro-button variant="ghost" ondark loading>Ghost</auro-button>
+<auro-button variant="flat" ondark loading>Flat</auro-button>

--- a/apiExamples/onDark.html
+++ b/apiExamples/onDark.html
@@ -1,3 +1,5 @@
 <auro-button ondark>Primary</auro-button>
 <auro-button variant="secondary" ondark>Secondary</auro-button>
 <auro-button variant="tertiary" ondark>Tertiary</auro-button>
+<auro-button variant="ghost" ondark>Ghost</auro-button>
+<auro-button variant="flat" ondark>Flat</auro-button>

--- a/apiExamples/roundedRightAlign.html
+++ b/apiExamples/roundedRightAlign.html
@@ -1,6 +1,6 @@
 <div style="display: flex; justify-content: flex-end; align-items: center; width: 100%">
   <auro-button arialabel="in-flight" shape="circle" id="rightAlignElem">
-    Text is now shown!
-    <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+    <span>Text is now shown!</span>
+    <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
   </auro-button>
 </div>

--- a/apiExamples/roundedTextWithIcon.html
+++ b/apiExamples/roundedTextWithIcon.html
@@ -1,4 +1,4 @@
 <auro-button arialabel="in-flight" rounded>
-  Back to Top
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <span>Back to Top</span>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>

--- a/apiExamples/shape-circle.html
+++ b/apiExamples/shape-circle.html
@@ -1,3 +1,3 @@
 <auro-button arialabel="arrow-up" shape="circle">
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>

--- a/apiExamples/shape-pill.html
+++ b/apiExamples/shape-pill.html
@@ -2,6 +2,6 @@
   Primary
 </auro-button>
 <auro-button arialabel="in-flight" shape="pill">
-  Back to Top
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <span>Back to Top</span>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>

--- a/apiExamples/shape.html
+++ b/apiExamples/shape.html
@@ -1,5 +1,5 @@
 <auro-button shape="rounded">Rounded Button</auro-button>
 <auro-button shape="pill">Pill Button</auro-button>
 <auro-button shape="circle">
-  <auro-icon slot="icon" customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
+  <auro-icon customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
 </auro-button>

--- a/apiExamples/toggledText.html
+++ b/apiExamples/toggledText.html
@@ -1,4 +1,4 @@
 <auro-button arialabel="arrow-up" shape="circle" id="toggledTextElem">
-  Text is now shown!
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <span>Text is now shown!</span>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>

--- a/demo/api.md
+++ b/demo/api.md
@@ -32,6 +32,7 @@
   <auro-button>Primary</auro-button>
   <auro-button variant="secondary">Secondary</auro-button>
   <auro-button variant="tertiary">Tertiary</auro-button>
+  <auro-button variant="ghost">Ghost</auro-button>
   <auro-button variant="flat">Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -44,6 +45,7 @@
 <auro-button>Primary</auro-button>
 <auro-button variant="secondary">Secondary</auro-button>
 <auro-button variant="tertiary">Tertiary</auro-button>
+<auro-button variant="ghost">Ghost</auro-button>
 <auro-button variant="flat">Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -54,6 +56,8 @@
   <auro-button ondark>Primary</auro-button>
   <auro-button variant="secondary" ondark>Secondary</auro-button>
   <auro-button variant="tertiary" ondark>Tertiary</auro-button>
+  <auro-button variant="ghost" ondark>Ghost</auro-button>
+  <auro-button variant="flat" ondark>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -65,6 +69,8 @@
 <auro-button ondark>Primary</auro-button>
 <auro-button variant="secondary" ondark>Secondary</auro-button>
 <auro-button variant="tertiary" ondark>Tertiary</auro-button>
+<auro-button variant="ghost" ondark>Ghost</auro-button>
+<auro-button variant="flat" ondark>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -79,6 +85,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
   <auro-button disabled>Primary</auro-button>
   <auro-button variant="secondary" disabled>Secondary</auro-button>
   <auro-button variant="tertiary" disabled>Tertiary</auro-button>
+  <auro-button variant="ghost" disabled>Ghost</auro-button>
+  <auro-button variant="flat" disabled>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -90,6 +98,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
 <auro-button disabled>Primary</auro-button>
 <auro-button variant="secondary" disabled>Secondary</auro-button>
 <auro-button variant="tertiary" disabled>Tertiary</auro-button>
+<auro-button variant="ghost" disabled>Ghost</auro-button>
+<auro-button variant="flat" disabled>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -99,6 +109,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
   <auro-button disabled ondark>Primary</auro-button>
   <auro-button variant="secondary" disabled ondark>Secondary</auro-button>
   <auro-button variant="tertiary" disabled ondark>Tertiary</auro-button>
+  <auro-button variant="ghost" disabled ondark>Ghost</auro-button>
+  <auro-button variant="flat" disabled ondark>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -110,6 +122,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
 <auro-button disabled ondark>Primary</auro-button>
 <auro-button variant="secondary" disabled ondark>Secondary</auro-button>
 <auro-button variant="tertiary" disabled ondark>Tertiary</auro-button>
+<auro-button variant="ghost" disabled ondark>Ghost</auro-button>
+<auro-button variant="flat" disabled ondark>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -126,16 +140,16 @@ Be sure to use the customColor attribute on the `auro-icon` component to allow c
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/icon.html) -->
   <!-- The below content is automatically added from ./../apiExamples/icon.html -->
   <auro-button arialabel="wifi">
-    Activate WiFi
-    <auro-icon customColor category="in-flight" name="wifi" slot="icon"></auro-icon>
+    <span>Activate WiFi</span>
+    <auro-icon customColor category="in-flight" name="wifi"></auro-icon>
   </auro-button>
   <auro-button variant="secondary" arialabel="arrow-left">
-    Previous action
-    <auro-icon customcolor category="interface" name="arrow-left" slot="icon"></auro-icon>
+    <span>Previous action</span>
+    <auro-icon customcolor category="interface" name="arrow-left" ></auro-icon>
   </auro-button>
   <auro-button variant="tertiary" arialabel="heart-filled">
-    Love this ...
-    <auro-icon customcolor category="interface" name="heart-filled" slot="icon"></auro-icon>
+    <span>Love this ...</span>
+    <auro-icon customcolor category="interface" name="heart-filled" ></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -146,16 +160,16 @@ Be sure to use the customColor attribute on the `auro-icon` component to allow c
 
 ```html
 <auro-button arialabel="wifi">
-  Activate WiFi
-  <auro-icon customColor category="in-flight" name="wifi" slot="icon"></auro-icon>
+  <span>Activate WiFi</span>
+  <auro-icon customColor category="in-flight" name="wifi"></auro-icon>
 </auro-button>
 <auro-button variant="secondary" arialabel="arrow-left">
-  Previous action
-  <auro-icon customcolor category="interface" name="arrow-left" slot="icon"></auro-icon>
+  <span>Previous action</span>
+  <auro-icon customcolor category="interface" name="arrow-left" ></auro-icon>
 </auro-button>
 <auro-button variant="tertiary" arialabel="heart-filled">
-  Love this ...
-  <auro-icon customcolor category="interface" name="heart-filled" slot="icon"></auro-icon>
+  <span>Love this ...</span>
+  <auro-icon customcolor category="interface" name="heart-filled" ></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -170,7 +184,7 @@ default - `rounded`
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/shape-circle.html) -->
   <!-- The below content is automatically added from ./../apiExamples/shape-circle.html -->
   <auro-button arialabel="arrow-up" shape="circle">
-    <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+    <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -181,7 +195,7 @@ default - `rounded`
 
 ```html
 <auro-button arialabel="arrow-up" shape="circle">
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -196,8 +210,8 @@ default - `rounded`
     Primary
   </auro-button>
   <auro-button arialabel="in-flight" shape="pill">
-    Back to Top
-    <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+    <span>Back to Top</span>
+    <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -211,8 +225,8 @@ default - `rounded`
   Primary
 </auro-button>
 <auro-button arialabel="in-flight" shape="pill">
-  Back to Top
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <span>Back to Top</span>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -226,8 +240,8 @@ The `rounded` attribute supports the ability to hide/show the text of the `auro-
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/toggledText.html) -->
   <!-- The below content is automatically added from ./../apiExamples/toggledText.html -->
   <auro-button arialabel="arrow-up" shape="circle" id="toggledTextElem">
-    Text is now shown!
-    <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+    <span>Text is now shown!</span>
+    <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -238,8 +252,8 @@ The `rounded` attribute supports the ability to hide/show the text of the `auro-
 
 ```html
 <auro-button arialabel="arrow-up" shape="circle" id="toggledTextElem">
-  Text is now shown!
-  <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+  <span>Text is now shown!</span>
+  <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -281,8 +295,8 @@ This example shows a `rounded` `auro-button` that is right-aligned, demonstratin
   <!-- The below content is automatically added from ./../apiExamples/roundedRightAlign.html -->
   <div style="display: flex; justify-content: flex-end; align-items: center; width: 100%">
     <auro-button arialabel="in-flight" shape="circle" id="rightAlignElem">
-      Text is now shown!
-      <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+      <span>Text is now shown!</span>
+      <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
     </auro-button>
   </div>
   <!-- AURO-GENERATED-CONTENT:END -->
@@ -295,8 +309,8 @@ This example shows a `rounded` `auro-button` that is right-aligned, demonstratin
 ```html
 <div style="display: flex; justify-content: flex-end; align-items: center; width: 100%">
   <auro-button arialabel="in-flight" shape="circle" id="rightAlignElem">
-    Text is now shown!
-    <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
+    <span>Text is now shown!</span>
+    <auro-icon customColor category="interface" name="arrow-up"></auro-icon>
   </auro-button>
 </div>
 ```
@@ -398,6 +412,8 @@ In the following example see how the `fluid` attributes alters the shape of the 
   <auro-button fluid>Primary</auro-button>
   <auro-button variant="secondary" fluid>Secondary</auro-button>
   <auro-button variant="tertiary" fluid>Tertiary</auro-button>
+  <auro-button variant="ghost" fluid>Ghost</auro-button>
+  <auro-button variant="flat" fluid>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -409,6 +425,8 @@ In the following example see how the `fluid` attributes alters the shape of the 
 <auro-button fluid>Primary</auro-button>
 <auro-button variant="secondary" fluid>Secondary</auro-button>
 <auro-button variant="tertiary" fluid>Tertiary</auro-button>
+<auro-button variant="ghost" fluid>Ghost</auro-button>
+<auro-button variant="flat" fluid>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -423,6 +441,8 @@ Use the `loading` attribute to alter the content to the shimmering dots to alert
   <auro-button loading>Primary</auro-button>
   <auro-button variant="secondary" loading>Secondary</auro-button>
   <auro-button variant="tertiary" loading>Tertiary</auro-button>
+  <auro-button variant="ghost" loading>Ghost</auro-button>
+  <auro-button variant="flat" loading>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -434,6 +454,8 @@ Use the `loading` attribute to alter the content to the shimmering dots to alert
 <auro-button loading>Primary</auro-button>
 <auro-button variant="secondary" loading>Secondary</auro-button>
 <auro-button variant="tertiary" loading>Tertiary</auro-button>
+<auro-button variant="ghost" loading>Ghost</auro-button>
+<auro-button variant="flat" loading>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -443,6 +465,8 @@ Use the `loading` attribute to alter the content to the shimmering dots to alert
   <auro-button ondark loading>Primary</auro-button>
   <auro-button variant="secondary" ondark loading>Secondary</auro-button>
   <auro-button variant="tertiary" ondark loading>Tertiary</auro-button>
+  <auro-button variant="ghost" ondark loading>Ghost</auro-button>
+  <auro-button variant="flat" ondark loading>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -454,6 +478,8 @@ Use the `loading` attribute to alter the content to the shimmering dots to alert
 <auro-button ondark loading>Primary</auro-button>
 <auro-button variant="secondary" ondark loading>Secondary</auro-button>
 <auro-button variant="tertiary" ondark loading>Tertiary</auro-button>
+<auro-button variant="ghost" ondark loading>Ghost</auro-button>
+<auro-button variant="flat" ondark loading>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>

--- a/demo/index.md
+++ b/demo/index.md
@@ -35,6 +35,7 @@ In cases were the action of the button would not fit the criteria above, it is m
   <auro-button>Primary</auro-button>
   <auro-button variant="secondary">Secondary</auro-button>
   <auro-button variant="tertiary">Tertiary</auro-button>
+  <auro-button variant="ghost">Ghost</auro-button>
   <auro-button variant="flat">Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -47,6 +48,7 @@ In cases were the action of the button would not fit the criteria above, it is m
 <auro-button>Primary</auro-button>
 <auro-button variant="secondary">Secondary</auro-button>
 <auro-button variant="tertiary">Tertiary</auro-button>
+<auro-button variant="ghost">Ghost</auro-button>
 <auro-button variant="flat">Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -62,6 +64,8 @@ These examples illustrate the core button types and a `disabled` state on dark b
   <auro-button ondark>Primary</auro-button>
   <auro-button variant="secondary" ondark>Secondary</auro-button>
   <auro-button variant="tertiary" ondark>Tertiary</auro-button>
+  <auro-button variant="ghost" ondark>Ghost</auro-button>
+  <auro-button variant="flat" ondark>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -73,6 +77,8 @@ These examples illustrate the core button types and a `disabled` state on dark b
 <auro-button ondark>Primary</auro-button>
 <auro-button variant="secondary" ondark>Secondary</auro-button>
 <auro-button variant="tertiary" ondark>Tertiary</auro-button>
+<auro-button variant="ghost" ondark>Ghost</auro-button>
+<auro-button variant="flat" ondark>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -87,6 +93,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
   <auro-button disabled>Primary</auro-button>
   <auro-button variant="secondary" disabled>Secondary</auro-button>
   <auro-button variant="tertiary" disabled>Tertiary</auro-button>
+  <auro-button variant="ghost" disabled>Ghost</auro-button>
+  <auro-button variant="flat" disabled>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -98,6 +106,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
 <auro-button disabled>Primary</auro-button>
 <auro-button variant="secondary" disabled>Secondary</auro-button>
 <auro-button variant="tertiary" disabled>Tertiary</auro-button>
+<auro-button variant="ghost" disabled>Ghost</auro-button>
+<auro-button variant="flat" disabled>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -107,6 +117,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
   <auro-button disabled ondark>Primary</auro-button>
   <auro-button variant="secondary" disabled ondark>Secondary</auro-button>
   <auro-button variant="tertiary" disabled ondark>Tertiary</auro-button>
+  <auro-button variant="ghost" disabled ondark>Ghost</auro-button>
+  <auro-button variant="flat" disabled ondark>Flat</auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
 <auro-accordion alignRight>
@@ -118,6 +130,8 @@ This example demonstrates `auro-button` in it's `disabled` state.
 <auro-button disabled ondark>Primary</auro-button>
 <auro-button variant="secondary" disabled ondark>Secondary</auro-button>
 <auro-button variant="tertiary" disabled ondark>Tertiary</auro-button>
+<auro-button variant="ghost" disabled ondark>Ghost</auro-button>
+<auro-button variant="flat" disabled ondark>Flat</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>
@@ -132,16 +146,16 @@ Be sure to use the `customColor` attribute on the auro-icon component to allow c
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/icon.html) -->
   <!-- The below content is automatically added from ./../apiExamples/icon.html -->
   <auro-button arialabel="wifi">
-    Activate WiFi
-    <auro-icon customColor category="in-flight" name="wifi" slot="icon"></auro-icon>
+    <span>Activate WiFi</span>
+    <auro-icon customColor category="in-flight" name="wifi"></auro-icon>
   </auro-button>
   <auro-button variant="secondary" arialabel="arrow-left">
-    Previous action
-    <auro-icon customcolor category="interface" name="arrow-left" slot="icon"></auro-icon>
+    <span>Previous action</span>
+    <auro-icon customcolor category="interface" name="arrow-left" ></auro-icon>
   </auro-button>
   <auro-button variant="tertiary" arialabel="heart-filled">
-    Love this ...
-    <auro-icon customcolor category="interface" name="heart-filled" slot="icon"></auro-icon>
+    <span>Love this ...</span>
+    <auro-icon customcolor category="interface" name="heart-filled" ></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -152,16 +166,16 @@ Be sure to use the `customColor` attribute on the auro-icon component to allow c
 
 ```html
 <auro-button arialabel="wifi">
-  Activate WiFi
-  <auro-icon customColor category="in-flight" name="wifi" slot="icon"></auro-icon>
+  <span>Activate WiFi</span>
+  <auro-icon customColor category="in-flight" name="wifi"></auro-icon>
 </auro-button>
 <auro-button variant="secondary" arialabel="arrow-left">
-  Previous action
-  <auro-icon customcolor category="interface" name="arrow-left" slot="icon"></auro-icon>
+  <span>Previous action</span>
+  <auro-icon customcolor category="interface" name="arrow-left" ></auro-icon>
 </auro-button>
 <auro-button variant="tertiary" arialabel="heart-filled">
-  Love this ...
-  <auro-icon customcolor category="interface" name="heart-filled" slot="icon"></auro-icon>
+  <span>Love this ...</span>
+  <auro-icon customcolor category="interface" name="heart-filled" ></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
@@ -204,7 +218,7 @@ The button comes with several different shapes available, pill, rounded, and cir
   <auro-button shape="rounded">Rounded Button</auro-button>
   <auro-button shape="pill">Pill Button</auro-button>
   <auro-button shape="circle">
-    <auro-icon slot="icon" customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
+    <auro-icon customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -217,7 +231,7 @@ The button comes with several different shapes available, pill, rounded, and cir
 <auro-button shape="rounded">Rounded Button</auro-button>
 <auro-button shape="pill">Pill Button</auro-button>
 <auro-button shape="circle">
-  <auro-icon slot="icon" customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
+  <auro-icon customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -23,7 +23,6 @@ import loaderVersion from './loaderVersion.js';
 
 /**
  * @slot - Default slot for the text of the button.
- * @slot icon - Slot to provide auro-icon for the button.
  * @csspart button - Apply CSS to HTML5 button.
  * @csspart loader - Apply CSS to auro-loader.
  * @csspart text - Apply CSS to text slot.
@@ -274,6 +273,7 @@ export class AuroButton extends AuroElement {
     const classes = {
       "util_insetLg--squish": true,
       "auro-button": true,
+      "icon-only": this.hideText,
       wrapper: true,
       loading: this.loading,
     };
@@ -299,11 +299,7 @@ export class AuroButton extends AuroElement {
 
         <span class="contentWrapper">
           <span class="textSlot" part="text">
-            ${this.hideText ? undefined : html`<slot></slot>`}
-          </span>
-
-          <span part="icon">
-            <slot name="icon"></slot>
+            <slot></slot>
           </span>
         </span>
       </button>

--- a/src/style.scss
+++ b/src/style.scss
@@ -184,6 +184,12 @@ slot {
     }
   }
 
+  &.icon-only{
+    ::slotted(:not(auro-icon):not([auro-icon])) {
+      display: none;
+    }
+  }
+
   // auro-button--slim
   &--slim {
     min-width: unset;

--- a/test/auro-button.test.js
+++ b/test/auro-button.test.js
@@ -244,19 +244,6 @@ describe('auro-button', () => {
     expect(el).to.be.true;
   });
 
-  it('default slot is not in DOM with circle shape', async () => {
-    const el = await fixture(html`
-      <auro-button shape="circle" aria-label="Up">
-        <auro-icon customColor category="interface" name="arrow-up" slot="icon"></auro-icon>
-        Text
-      </auro-button>
-    `);
-
-    const slotElement = el.querySelector('slot:not([name])');
-
-    expect(slotElement).to.not.exist;
-  });
-
   it('handles form awareness with type="submit"', async () => {
     const el = await fixture(html`
       <form id="test-form">


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #325

- icon slot is removed.
- docs updated to show all variants.
- docs updated that labels to be wrapped when it's with an icon.
- one test case is removed which was not meaningful.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Remove the deprecated icon slot from auro-button, streamline icon usage via the default slot and CSS, add a ghost variant, and update all related docs and examples.

New Features:
- Introduce the new “ghost” variant for auro-button.

Enhancements:
- Remove the named “icon” slot and simplify icon rendering by using the default slot wrapped in spans and adding an icon-only CSS style.

Documentation:
- Update documentation, demos, API examples, and README to reflect the removal of the icon slot and showcase the new ghost variant.

Tests:
- Remove the obsolete test for default slot behavior on circle-shaped buttons.