### PR TITLE
refactor: hide label only visually but not for screenreader for icon-only button

### DIFF
--- a/apiExamples/shape.html
+++ b/apiExamples/shape.html
@@ -1,5 +1,6 @@
 <auro-button shape="rounded">Rounded Button</auro-button>
 <auro-button shape="pill">Pill Button</auro-button>
 <auro-button shape="circle">
-  <auro-icon customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
+  <span>Account</span>
+  <auro-icon aria-hidden="true" customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
 </auro-button>

--- a/demo/index.md
+++ b/demo/index.md
@@ -218,7 +218,8 @@ The button comes with several different shapes available, pill, rounded, and cir
   <auro-button shape="rounded">Rounded Button</auro-button>
   <auro-button shape="pill">Pill Button</auro-button>
   <auro-button shape="circle">
-    <auro-icon customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
+    <span>Account</span>
+    <auro-icon aria-hidden="true" customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
   </auro-button>
   <!-- AURO-GENERATED-CONTENT:END -->
 </div>
@@ -231,7 +232,8 @@ The button comes with several different shapes available, pill, rounded, and cir
 <auro-button shape="rounded">Rounded Button</auro-button>
 <auro-button shape="pill">Pill Button</auro-button>
 <auro-button shape="circle">
-  <auro-icon customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
+  <span>Account</span>
+  <auro-icon aria-hidden="true" customcolor category="interface" name="account-filled" ondark="true"></auro-icon>
 </auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->

--- a/src/style.scss
+++ b/src/style.scss
@@ -186,7 +186,15 @@ slot {
 
   &.icon-only{
     ::slotted(:not(auro-icon):not([auro-icon])) {
-      display: none;
+      position: absolute;
+      pointer-events: none;
+      opacity: 0;
+      overflow: hidden;
+      clip: rect(1px, 1px, 1px, 1px);
+      width: 1px;
+      height: 1px;
+      padding: unset;
+      border: unset;
     }
   }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

close #334 

hide non-icon elements only visually but not for screen reader (same as `util_displayVisuallyHidden`)

**Before**
```
<!-- screen reader will speak "button"->
<auro-button shape="circle">
  <span>Account</span>
  <auro-icon ...></auro-icon>
</auro-button>
```

**After**
```
<!-- screen reader will speak "Account, button"-->
<auro-button shape="circle">
  <span>Account</span>
  <auro-icon ...></auro-icon>
</auro-button>
```

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Hide non-icon slotted elements visually but not from screen readers for icon-only buttons, replacing display:none with visually hidden styling and updating demos and examples to include accessible text spans and aria-hidden icons.

Enhancements:
- Use visually hidden CSS (position absolute, clip, zero-size, etc.) instead of display:none for non-icon slotted elements in .icon-only mode to maintain screen reader accessibility

Documentation:
- Revise demo and API example markup for icon-only buttons to wrap labels in <span> and add aria-hidden="true" to <auro-icon>