### PR TITLE
Add component name attribute when registering

### DIFF
--- a/demo/api.md
+++ b/demo/api.md
@@ -5,22 +5,23 @@
 
 ## Properties
 
-| Property      | Attribute     | Type                                             | Default   | Description                                      |
-|---------------|---------------|--------------------------------------------------|-----------|--------------------------------------------------|
-| [autofocus](#autofocus)   | `autofocus`   | `boolean`                                        | false     | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user. |
-| [disabled](#disabled)    | `disabled`    | `boolean`                                        | false     | If set to true, button will become disabled and not allow for interactions. |
-| [fluid](#fluid)       | `fluid`       | `boolean`                                        | false     | Alters the shape of the button to be full width of its parent container. |
-| [loading](#loading)     | `loading`     | `boolean`                                        | false     | If set to true button text will be replaced with `auro-loader` and become disabled. |
-| [loadingText](#loadingText) | `loadingText` | `string`                                         |           | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
-| [onDark](#onDark)      |               | `boolean`                                        | false     | Indicates if the button is rendered in dark mode. |
-| [shape](#shape)       |               | `'default', 'rounded', 'pill', 'circle', 'square'` | "rounded" | Defines the shape of the button.                 |
-| [size](#size)        |               | `'xs', 'sm', 'md', 'lg', 'xl'`                   | "md"      | Defines the size of the button.                  |
-| [tIndex](#tIndex)      | `tIndex`      | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation. |
-| [tabindex](#tabindex)    | `tabindex`    | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation.<br />Must be used with "." to ensure the host element does not retain a reference to the `tabindex` attribute.<br />Example: `<auro-button .tabindex="${this.disabled ? '-1' : '0'}"></auro-button>`. |
-| [title](#title)       | `title`       | `string`                                         |           | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
-| [type](#type)        | `type`        | `'submit', 'reset', 'button'`                    |           | The type of button. Matches HTML5 Button Spec.   |
-| [value](#value)       | `value`       | `string`                                         |           | Defines the value associated with the button which is submitted with the form data. |
-| [variant](#variant)     | `variant`     | `'primary', 'secondary', 'tertiary', 'ghost', 'flat'` | "primary" | Sets the button variant.                         |
+| Property       | Attribute     | Type                                             | Default   | Description                                      |
+|----------------|---------------|--------------------------------------------------|-----------|--------------------------------------------------|
+| [autofocus](#autofocus)    | `autofocus`   | `boolean`                                        | false     | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user. |
+| [disabled](#disabled)     | `disabled`    | `boolean`                                        | false     | If set to true, button will become disabled and not allow for interactions. |
+| [fluid](#fluid)        | `fluid`       | `boolean`                                        | false     | Alters the shape of the button to be full width of its parent container. |
+| [loading](#loading)      | `loading`     | `boolean`                                        | false     | If set to true button text will be replaced with `auro-loader` and become disabled. |
+| [loadingText](#loadingText)  | `loadingText` | `string`                                         |           | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
+| [onDark](#onDark)       |               | `boolean`                                        | false     | Indicates if the button is rendered in dark mode. |
+| [runtimeUtils](#runtimeUtils) |               |                                                  |           |                                                  |
+| [shape](#shape)        |               | `'default', 'rounded', 'pill', 'circle', 'square'` | "rounded" | Defines the shape of the button.                 |
+| [size](#size)         |               | `'xs', 'sm', 'md', 'lg', 'xl'`                   | "md"      | Defines the size of the button.                  |
+| [tIndex](#tIndex)       | `tIndex`      | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation. |
+| [tabindex](#tabindex)     | `tabindex`    | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation.<br />Must be used with "." to ensure the host element does not retain a reference to the `tabindex` attribute.<br />Example: `<auro-button .tabindex="${this.disabled ? '-1' : '0'}"></auro-button>`. |
+| [title](#title)        | `title`       | `string`                                         |           | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
+| [type](#type)         | `type`        | `'submit', 'reset', 'button'`                    |           | The type of button. Matches HTML5 Button Spec.   |
+| [value](#value)        | `value`       | `string`                                         |           | Defines the value associated with the button which is submitted with the form data. |
+| [variant](#variant)      | `variant`     | `'primary', 'secondary', 'tertiary', 'ghost', 'flat'` | "primary" | Sets the button variant.                         |
 <!-- AURO-GENERATED-CONTENT:END -->
 
 # API Examples

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,19 +2,20 @@
 
 ## Properties
 
-| Property      | Attribute     | Type                                             | Default   | Description                                      |
-|---------------|---------------|--------------------------------------------------|-----------|--------------------------------------------------|
-| `autofocus`   | `autofocus`   | `boolean`                                        | false     | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user. |
-| `disabled`    | `disabled`    | `boolean`                                        | false     | If set to true, button will become disabled and not allow for interactions. |
-| `fluid`       | `fluid`       | `boolean`                                        | false     | Alters the shape of the button to be full width of its parent container. |
-| `loading`     | `loading`     | `boolean`                                        | false     | If set to true button text will be replaced with `auro-loader` and become disabled. |
-| `loadingText` | `loadingText` | `string`                                         |           | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
-| `onDark`      |               | `boolean`                                        | false     | Indicates if the button is rendered in dark mode. |
-| `shape`       |               | `'default', 'rounded', 'pill', 'circle', 'square'` | "rounded" | Defines the shape of the button.                 |
-| `size`        |               | `'xs', 'sm', 'md', 'lg', 'xl'`                   | "md"      | Defines the size of the button.                  |
-| `tIndex`      | `tIndex`      | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation. |
-| `tabindex`    | `tabindex`    | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation.<br />Must be used with "." to ensure the host element does not retain a reference to the `tabindex` attribute.<br />Example: `<auro-button .tabindex="${this.disabled ? '-1' : '0'}"></auro-button>`. |
-| `title`       | `title`       | `string`                                         |           | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
-| `type`        | `type`        | `'submit', 'reset', 'button'`                    |           | The type of button. Matches HTML5 Button Spec.   |
-| `value`       | `value`       | `string`                                         |           | Defines the value associated with the button which is submitted with the form data. |
-| `variant`     | `variant`     | `'primary', 'secondary', 'tertiary', 'ghost', 'flat'` | "primary" | Sets the button variant.                         |
+| Property       | Attribute     | Type                                             | Default   | Description                                      |
+|----------------|---------------|--------------------------------------------------|-----------|--------------------------------------------------|
+| `autofocus`    | `autofocus`   | `boolean`                                        | false     | This Boolean attribute lets you specify that the button should have input focus when the page loads, unless overridden by the user. |
+| `disabled`     | `disabled`    | `boolean`                                        | false     | If set to true, button will become disabled and not allow for interactions. |
+| `fluid`        | `fluid`       | `boolean`                                        | false     | Alters the shape of the button to be full width of its parent container. |
+| `loading`      | `loading`     | `boolean`                                        | false     | If set to true button text will be replaced with `auro-loader` and become disabled. |
+| `loadingText`  | `loadingText` | `string`                                         |           | Sets custom loading text for the `aria-label` on a button in loading state. If not set, the default value of "Loading..." will be used. |
+| `onDark`       |               | `boolean`                                        | false     | Indicates if the button is rendered in dark mode. |
+| `runtimeUtils` |               |                                                  |           |                                                  |
+| `shape`        |               | `'default', 'rounded', 'pill', 'circle', 'square'` | "rounded" | Defines the shape of the button.                 |
+| `size`         |               | `'xs', 'sm', 'md', 'lg', 'xl'`                   | "md"      | Defines the size of the button.                  |
+| `tIndex`       | `tIndex`      | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation. |
+| `tabindex`     | `tabindex`    | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation.<br />Must be used with "." to ensure the host element does not retain a reference to the `tabindex` attribute.<br />Example: `<auro-button .tabindex="${this.disabled ? '-1' : '0'}"></auro-button>`. |
+| `title`        | `title`       | `string`                                         |           | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
+| `type`         | `type`        | `'submit', 'reset', 'button'`                    |           | The type of button. Matches HTML5 Button Spec.   |
+| `value`        | `value`       | `string`                                         |           | Defines the value associated with the button which is submitted with the form data. |
+| `variant`      | `variant`     | `'primary', 'secondary', 'tertiary', 'ghost', 'flat'` | "primary" | Sets the button variant.                         |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-button",
-  "version": "11.2.1",
+  "version": "11.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-button",
-      "version": "11.2.1",
+      "version": "11.3.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -18,7 +18,7 @@ import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 import { AuroDependencyVersioning } from '@aurodesignsystem/auro-library/scripts/runtime/dependencyTagVersioning.mjs';
-import * as RuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
+import AuroLibraryRuntimeUtils from '@aurodesignsystem/auro-library/scripts/utils/runtimeUtils.mjs';
 
 import styleCss from "./styles/style-css.js";
 import colorCss from "./styles/color-css.js";
@@ -69,6 +69,8 @@ export class AuroButton extends AuroElement {
     this.fluid = false;
     this.loadingText = this.loadingText || 'Loading...';
     this.variant = 'primary';
+
+    this.runtimeUtils = new AuroLibraryRuntimeUtils();
 
     // Support for HTML5 forms
     if (typeof this.attachInternals === 'function') {
@@ -252,7 +254,7 @@ export class AuroButton extends AuroElement {
    *
    */
   static register(name = "auro-button") {
-    RuntimeUtils.default.prototype.registerComponent(name, AuroButton);
+    AuroLibraryRuntimeUtils.prototype.registerComponent(name, AuroButton);
   }
 
   /**
@@ -355,6 +357,12 @@ export class AuroButton extends AuroElement {
 
     // Return the font size based on the button size and shape
     return sizeMap[this.size] || 'body-default';
+  }
+
+  firstUpdated() {
+    super.firstUpdated();
+
+    this.runtimeUtils.handleComponentTagRename(this, 'auro-button');
   }
 
   /**

--- a/src/auro-button.js
+++ b/src/auro-button.js
@@ -70,6 +70,9 @@ export class AuroButton extends AuroElement {
     this.loadingText = this.loadingText || 'Loading...';
     this.variant = 'primary';
 
+    /**
+     * @private
+     */
     this.runtimeUtils = new AuroLibraryRuntimeUtils();
 
     // Support for HTML5 forms


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

I copied the pattern that Input and formkit elements use, so this is just unifying functionality :)

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Integrate AuroLibraryRuntimeUtils into AuroButton to unify component registration and support automatic tag renaming, and update API documentation accordingly

Enhancements:
- Instantiate AuroLibraryRuntimeUtils in AuroButton constructor and use it for component registration
- Call handleComponentTagRename in firstUpdated to support legacy tag renaming

Documentation:
- Add runtimeUtils entry to the AuroButton API tables in demo and documentation