### PR TITLE
feat: add static button functionality #346

### DIFF
--- a/apiExamples/static.html
+++ b/apiExamples/static.html
@@ -1,0 +1,30 @@
+<auro-button static>Static Primary Button</auro-button>
+<auro-button static variant="secondary">Static Secondary Button</auro-button>
+<auro-button static variant="tertiary">Static Tertiary Button</auro-button>
+
+<br><br>
+
+<auro-button static fluid>Static Fluid Button</auro-button>
+
+<br><br>
+
+<auro-button static size="xs">XS Static</auro-button>
+<auro-button static size="sm">SM Static</auro-button>
+<auro-button static size="md">MD Static</auro-button>
+<auro-button static size="lg">LG Static</auro-button>
+<auro-button static size="xl">XL Static</auro-button>
+
+<br><br>
+
+<auro-button static shape="pill">
+  <auro-icon name="home" slot="icon" customColor></auro-icon>
+  Static Pill with Icon
+</auro-button>
+
+<auro-button static shape="circle">
+  <auro-icon name="home" customColor></auro-icon>
+</auro-button>
+
+<auro-button static shape="square">
+  <auro-icon name="home" customColor></auro-icon>
+</auro-button>

--- a/apiExamples/staticOnDark.html
+++ b/apiExamples/staticOnDark.html
@@ -1,0 +1,3 @@
+<auro-button static onDark>Static Primary Button</auro-button>
+<auro-button static variant="secondary" onDark>Static Secondary Button</auro-button>
+<auro-button static variant="tertiary" onDark>Static Tertiary Button</auro-button>

--- a/demo/api.md
+++ b/demo/api.md
@@ -15,6 +15,7 @@
 | [onDark](#onDark)      |               | `boolean`                                        | false     | Indicates if the button is rendered in dark mode. |
 | [shape](#shape)       |               | `'default', 'rounded', 'pill', 'circle', 'square'` | "rounded" | Defines the shape of the button.                 |
 | [size](#size)        |               | `'xs', 'sm', 'md', 'lg', 'xl'`                   | "md"      | Defines the size of the button.                  |
+| [static](#static)      | `static`      | `boolean`                                        | false     | If true, the button will be static and not respond to user interactions. |
 | [tIndex](#tIndex)      | `tIndex`      | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation. |
 | [tabindex](#tabindex)    | `tabindex`    | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation.<br />Must be used with "." to ensure the host element does not retain a reference to the `tabindex` attribute.<br />Example: `<auro-button .tabindex="${this.disabled ? '-1' : '0'}"></auro-button>`. |
 | [title](#title)       | `title`       | `string`                                         |           | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |
@@ -141,6 +142,89 @@ This example demonstrates `auro-button` in it's `disabled` state.
 <auro-button variant="secondary" disabled ondark>Secondary</auro-button>
 <auro-button variant="tertiary" disabled ondark>Tertiary</auro-button>
 <auro-button variant="ghost" disabled ondark>Ghost</auro-button>
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+
+## Static
+
+The `static` attribute creates a button with no interactivity. When applied, the button becomes non-clickable and serves purely as a visual element. This is useful for displaying button-styled elements that need to appear interactive but should not respond to user input, such as buttons within clickable cards or slides.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/static.html) -->
+  <!-- The below content is automatically added from ./../apiExamples/static.html -->
+  <auro-button static>Static Primary Button</auro-button>
+  <auro-button static variant="secondary">Static Secondary Button</auro-button>
+  <auro-button static variant="tertiary">Static Tertiary Button</auro-button>
+  <br><br>
+  <auro-button static fluid>Static Fluid Button</auro-button>
+  <br><br>
+  <auro-button static size="xs">XS Static</auro-button>
+  <auro-button static size="sm">SM Static</auro-button>
+  <auro-button static size="md">MD Static</auro-button>
+  <auro-button static size="lg">LG Static</auro-button>
+  <auro-button static size="xl">XL Static</auro-button>
+  <br><br>
+  <auro-button static shape="pill">
+    <auro-icon name="home" slot="icon" customColor></auro-icon>
+    Static Pill with Icon
+  </auro-button>
+  <auro-button static shape="circle">
+    <auro-icon name="home" customColor></auro-icon>
+  </auro-button>
+  <auro-button static shape="square">
+    <auro-icon name="home" customColor></auro-icon>
+  </auro-button>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/static.html) -->
+<!-- The below code snippet is automatically added from ./../apiExamples/static.html -->
+
+```html
+<auro-button static>Static Primary Button</auro-button>
+<auro-button static variant="secondary">Static Secondary Button</auro-button>
+<auro-button static variant="tertiary">Static Tertiary Button</auro-button>
+<br><br>
+<auro-button static fluid>Static Fluid Button</auro-button>
+<br><br>
+<auro-button static size="xs">XS Static</auro-button>
+<auro-button static size="sm">SM Static</auro-button>
+<auro-button static size="md">MD Static</auro-button>
+<auro-button static size="lg">LG Static</auro-button>
+<auro-button static size="xl">XL Static</auro-button>
+<br><br>
+<auro-button static shape="pill">
+  <auro-icon name="home" slot="icon" customColor></auro-icon>
+  Static Pill with Icon
+</auro-button>
+<auro-button static shape="circle">
+  <auro-icon name="home" customColor></auro-icon>
+</auro-button>
+<auro-button static shape="square">
+  <auro-icon name="home" customColor></auro-icon>
+</auro-button>
+```
+<!-- AURO-GENERATED-CONTENT:END -->
+</auro-accordion>
+<div class="exampleWrapper--ondark">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/staticOnDark.html) -->
+  <!-- The below content is automatically added from ./../apiExamples/staticOnDark.html -->
+  <auro-button static onDark>Static Primary Button</auro-button>
+  <auro-button static variant="secondary" onDark>Static Secondary Button</auro-button>
+  <auro-button static variant="tertiary" onDark>Static Tertiary Button</auro-button>
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/staticOnDark.html) -->
+<!-- The below code snippet is automatically added from ./../apiExamples/staticOnDark.html -->
+
+```html
+<auro-button static onDark>Static Primary Button</auro-button>
+<auro-button static variant="secondary" onDark>Static Secondary Button</auro-button>
+<auro-button static variant="tertiary" onDark>Static Tertiary Button</auro-button>
 ```
 <!-- AURO-GENERATED-CONTENT:END -->
 </auro-accordion>

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@
 | `onDark`      |               | `boolean`                                        | false     | Indicates if the button is rendered in dark mode. |
 | `shape`       |               | `'default', 'rounded', 'pill', 'circle', 'square'` | "rounded" | Defines the shape of the button.                 |
 | `size`        |               | `'xs', 'sm', 'md', 'lg', 'xl'`                   | "md"      | Defines the size of the button.                  |
+| `static`      | `static`      | `boolean`                                        | false     | If true, the button will be static and not respond to user interactions. |
 | `tIndex`      | `tIndex`      | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation. |
 | `tabindex`    | `tabindex`    | `string`                                         |           | Populates `tabindex` to define the focusable sequence in keyboard navigation.<br />Must be used with "." to ensure the host element does not retain a reference to the `tabindex` attribute.<br />Example: `<auro-button .tabindex="${this.disabled ? '-1' : '0'}"></auro-button>`. |
 | `title`       | `title`       | `string`                                         |           | Sets title attribute. The information is most often shown as a tooltip text when the mouse moves over the element. |

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -61,6 +61,36 @@ This example demonstrates `auro-button` in it's `disabled` state.
 
 </auro-accordion>
 
+## Static
+
+The `static` attribute creates a button with no interactivity. When applied, the button becomes non-clickable and serves purely as a visual element. This is useful for displaying button-styled elements that need to appear interactive but should not respond to user input, such as buttons within clickable cards or slides.
+
+<div class="exampleWrapper">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/static.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/static.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
+<div class="exampleWrapper--ondark">
+  <!-- AURO-GENERATED-CONTENT:START (FILE:src=./../apiExamples/staticOnDark.html) -->
+  <!-- AURO-GENERATED-CONTENT:END -->
+</div>
+
+<auro-accordion alignRight>
+  <span slot="trigger">See code</span>
+
+<!-- AURO-GENERATED-CONTENT:START (CODE:src=./../apiExamples/staticOnDark.html) -->
+<!-- AURO-GENERATED-CONTENT:END -->
+
+</auro-accordion>
+
 ## Icon Support
 
 Adding icons to the auro-button component is as easy as nesting any other HTML. The auro-icon component 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@aurodesignsystem/auro-button",
-  "version": "11.3.3",
+  "version": "11.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-button",
-      "version": "11.3.3",
+      "version": "11.3.4",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-library": "^5.4.0",
+        "@aurodesignsystem/auro-library": "^5.5.2",
         "@aurodesignsystem/auro-loader": "^5.1.2",
-        "@aurodesignsystem/design-tokens": "^8.4.1",
+        "@aurodesignsystem/design-tokens": "^8.4.2",
         "@aurodesignsystem/webcorestylesheets": "10.0.4",
         "chalk": "^5.4.1",
         "lit": "^3.3.0"
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.4.0.tgz",
-      "integrity": "sha512-CuivH8Kk5iOfdth/jGjLTQ95Ly/8N3htzdP9d2meIV6TRWI4Y7vBl9Ee5JTAY9cNiydHsCthbXFKX7lC6PWh3w==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.5.2.tgz",
+      "integrity": "sha512-Qt1qjNhXcPn23gRw4w+W2IB5sVvmixi5oxp19YmE1ZYsygI7J/0BWmXsX+DH8ZQi2OhpKyS3ddSGk7GrlY2TdA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.11",
@@ -258,10 +258,11 @@
       }
     },
     "node_modules/@aurodesignsystem/design-tokens": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.1.tgz",
-      "integrity": "sha512-eL3WJAroHWrkoRi/5h53auyFzNiS57mxfdjML8C6nf8wV+KtJvwiNU0oaGsLHPAzicLPxuptkEM04oTo+V8LQw==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.2.tgz",
+      "integrity": "sha512-sbFI6sRfV4z81cTp0GGCfgMWLpZX/mQ0P/4MAIyzxGgJ+x5yDGlfBW80Vr8no3bsAWPgMCINwrN498JM/9loxw==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.4.1",
         "postcss": "^8.5.6"
@@ -410,6 +411,20 @@
       },
       "peerDependencies": {
         "sass": "^1.42.1"
+      }
+    },
+    "node_modules/@aurodesignsystem/webcorestylesheets/node_modules/@aurodesignsystem/design-tokens": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/design-tokens/-/design-tokens-8.4.1.tgz",
+      "integrity": "sha512-eL3WJAroHWrkoRi/5h53auyFzNiS57mxfdjML8C6nf8wV+KtJvwiNU0oaGsLHPAzicLPxuptkEM04oTo+V8LQw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "postcss": "^8.5.6"
+      },
+      "engines": {
+        "node": "^20.x || ^22.x"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "node": "^20.x || ^22.x "
   },
   "dependencies": {
-    "@aurodesignsystem/auro-library": "^5.4.0",
+    "@aurodesignsystem/auro-library": "^5.5.2",
     "@aurodesignsystem/auro-loader": "^5.1.2",
-    "@aurodesignsystem/design-tokens": "^8.4.1",
+    "@aurodesignsystem/design-tokens": "^8.4.2",
     "@aurodesignsystem/webcorestylesheets": "10.0.4",
     "chalk": "^5.4.1",
     "lit": "^3.3.0"

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -35,7 +35,9 @@
    selector-max-pseudo-class,
    selector-not-notation,
    scss/map-keys-quotes,
-   scss/no-global-function-names
+   scss/no-global-function-names,
+   selector-max-combinators,
+   selector-max-compound-selectors
    */
 
 /**
@@ -467,3 +469,14 @@ slot {
   }
 }
 
+:host([static]) {
+  .auro-button {
+    pointer-events: none;
+    cursor: default;
+    display: inline-flex;
+
+    .contentWrapper {
+       display: inline-flex;
+    }
+  }
+}

--- a/test/auro-button.test.js
+++ b/test/auro-button.test.js
@@ -299,4 +299,17 @@ describe('auro-button', () => {
 
     expect(el.form).to.be.null;
   })
+
+  it('if static attribute is set', async () => {
+    const el = await fixture(html`
+      <auro-button static>Static Button</auro-button>
+    `);
+
+    const root = el.shadowRoot;
+    const span = root.querySelector('span');
+
+    expect(span).to.not.be.null;
+    expect(root.querySelector('button')).to.be.null;
+    expect(el.hasAttribute('static')).to.be.true;
+  })
 });


### PR DESCRIPTION
# Alaska Airlines Pull Request

Add the `static` attribute that converts button into a decorative element.
Review link: https://auro-button-pr348-1.surge.sh/api

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Add a static mode to auro-button so it renders as a decorative, non-interactive element, with updated rendering logic, styling, documentation, tests, and dependencies.

New Features:
- Introduce static attribute to render the button as a non-interactive decorative element

Enhancements:
- Adjust rendering logic to use a span for static buttons and disable their tabindex and click handling
- Add CSS rules to disable pointer events and set a default cursor for static buttons
- Bump AURO library and design-tokens dependencies and extend stylelint rules

Documentation:
- Document the static attribute in the API and add usage examples for light and dark modes

Tests:
- Add a unit test to verify that the static attribute renders a span and disables interactivity